### PR TITLE
Fix unreadable dark mode under vibrancy, and add a theme preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ require Krypton Runtime to be installed.
 - Editing: the YAML tab writes back as a full replace, so an object
   someone else changed underneath you is rejected rather than silently
   overwritten. Deleting is deliberately not implemented yet
+- Light, dark, or follow-the-system appearance, remembered in
+  `settings.json` beside the app's other config
 - Pod logs, streamed live — with container selection, timestamps, and
   `previous` for reading why a crashed container died
 

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -39,6 +39,11 @@ pub enum AppError {
     #[error("{0}")]
     Conflict(String),
 
+    /// Preferences could not be read or written. Never fatal: the app
+    /// falls back to defaults and says so rather than refusing to start.
+    #[error("settings: {0}")]
+    Settings(String),
+
     /// The API server rejected or failed the request. Carries the
     /// original message so RBAC denials stay legible to the user.
     #[error("kubernetes: {0}")]
@@ -55,6 +60,7 @@ impl AppError {
             AppError::UnknownResource(_) => "unknown_resource",
             AppError::InvalidEdit(_) => "invalid_edit",
             AppError::Conflict(_) => "conflict",
+            AppError::Settings(_) => "settings",
             AppError::Kube(_) => "kubernetes",
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod cluster;
 mod error;
+mod settings;
 mod vibrancy;
 
 use cluster::{ClusterInfo, ContextInfo, SharedSession};
@@ -236,6 +237,20 @@ fn log_streams() -> &'static cluster::logs::LogStreams {
     STREAMS.get_or_init(cluster::logs::LogStreams::default)
 }
 
+#[tauri::command]
+fn get_settings(app: tauri::AppHandle) -> settings::Settings {
+    settings::load(&app)
+}
+
+/// Records the chosen appearance and returns the settings as stored.
+#[tauri::command]
+fn set_theme(app: tauri::AppHandle, theme: settings::Theme) -> Result<settings::Settings> {
+    let mut current = settings::load(&app);
+    current.theme = theme;
+    settings::save(&app, &current)?;
+    Ok(current)
+}
+
 /// Whether native window vibrancy is actually active.
 ///
 /// The frontend asks at startup rather than guessing from the platform:
@@ -283,6 +298,8 @@ pub fn run() {
             get_helm_release,
             start_pod_logs,
             stop_pod_logs,
+            get_settings,
+            set_theme,
             vibrancy_enabled,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -50,17 +50,23 @@ fn settings_path(app: &tauri::AppHandle) -> Result<PathBuf> {
 /// defaults — the user can always delete the file, and the next save
 /// rewrites it.
 pub fn load(app: &tauri::AppHandle) -> Settings {
-    let Ok(path) = settings_path(app) else {
-        return Settings::default();
-    };
-    let Ok(text) = std::fs::read_to_string(&path) else {
-        return Settings::default();
-    };
-    parse(&text)
+    match settings_path(app) {
+        Ok(path) => read_from(&path),
+        Err(_) => Settings::default(),
+    }
 }
 
-/// Split from `load` so the fallback behaviour can be tested without a
-/// Tauri app handle or a real config directory.
+/// Split from `load` so the fallback behaviour can be tested against a
+/// real file without a Tauri app handle or the user's config directory.
+pub(crate) fn read_from(path: &std::path::Path) -> Settings {
+    match std::fs::read_to_string(path) {
+        Ok(text) => parse(&text),
+        // Missing is the first-run case and is not worth distinguishing
+        // from unreadable: both mean "no preference recorded".
+        Err(_) => Settings::default(),
+    }
+}
+
 pub(crate) fn parse(text: &str) -> Settings {
     serde_json::from_str(text).unwrap_or_default()
 }
@@ -71,7 +77,12 @@ pub(crate) fn parse(text: &str) -> Settings {
 /// leaves the previous settings intact rather than a truncated file that
 /// reads as corrupt on next launch.
 pub fn save(app: &tauri::AppHandle, settings: &Settings) -> Result<()> {
-    let path = settings_path(app)?;
+    write_to(&settings_path(app)?, settings)
+}
+
+/// Split from `save` for the same reason as `read_from`: the write is
+/// the part with a failure mode worth testing.
+pub(crate) fn write_to(path: &std::path::Path, settings: &Settings) -> Result<()> {
     if let Some(dir) = path.parent() {
         std::fs::create_dir_all(dir)
             .map_err(|e| AppError::Settings(format!("create {}: {e}", dir.display())))?;
@@ -83,7 +94,7 @@ pub fn save(app: &tauri::AppHandle, settings: &Settings) -> Result<()> {
     let temp = path.with_extension("json.tmp");
     std::fs::write(&temp, json.as_bytes())
         .map_err(|e| AppError::Settings(format!("write {}: {e}", temp.display())))?;
-    std::fs::rename(&temp, &path)
+    std::fs::rename(&temp, path)
         .map_err(|e| AppError::Settings(format!("replace {}: {e}", path.display())))?;
 
     Ok(())
@@ -142,5 +153,104 @@ mod tests {
     fn a_valid_file_is_honoured() {
         assert_eq!(parse(r#"{"theme":"dark"}"#).theme, Theme::Dark);
         assert_eq!(parse(r#"{"theme":"light"}"#).theme, Theme::Light);
+    }
+
+    /// A scratch directory that removes itself, so the file tests below
+    /// leave nothing behind and cannot collide with each other.
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            // Nanoseconds plus the test's own name: `cargo test` runs
+            // these in parallel and a shared path would flake.
+            let stamp = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let dir = std::env::temp_dir().join(format!("loupe-settings-{tag}-{stamp}"));
+            std::fs::create_dir_all(&dir).expect("create scratch dir");
+            TempDir(dir)
+        }
+
+        fn join(&self, name: &str) -> PathBuf {
+            self.0.join(name)
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn settings_survive_a_write_and_a_read() {
+        let dir = TempDir::new("roundtrip");
+        let path = dir.join("settings.json");
+
+        write_to(&path, &Settings { theme: Theme::Dark }).expect("write");
+        assert_eq!(read_from(&path).theme, Theme::Dark);
+    }
+
+    #[test]
+    fn writing_creates_the_config_directory() {
+        // First run on a machine that has never opened Loupe: the
+        // directory does not exist yet, and a failure here would mean
+        // the preference silently never persists.
+        let dir = TempDir::new("mkdir");
+        let path = dir.join("nested").join("deeper").join("settings.json");
+
+        write_to(
+            &path,
+            &Settings {
+                theme: Theme::Light,
+            },
+        )
+        .expect("write");
+        assert!(path.exists());
+        assert_eq!(read_from(&path).theme, Theme::Light);
+    }
+
+    #[test]
+    fn a_second_write_replaces_the_first() {
+        let dir = TempDir::new("replace");
+        let path = dir.join("settings.json");
+
+        write_to(&path, &Settings { theme: Theme::Dark }).expect("first");
+        write_to(
+            &path,
+            &Settings {
+                theme: Theme::Light,
+            },
+        )
+        .expect("second");
+
+        assert_eq!(read_from(&path).theme, Theme::Light);
+        // The temporary file is renamed, not left behind.
+        assert!(
+            !path.with_extension("json.tmp").exists(),
+            "the temp file should not survive a completed write"
+        );
+    }
+
+    #[test]
+    fn a_file_that_is_not_there_reads_as_default() {
+        let dir = TempDir::new("missing");
+        assert_eq!(read_from(&dir.join("nothing.json")).theme, Theme::System);
+    }
+
+    #[test]
+    fn a_corrupt_file_on_disk_does_not_stop_the_app() {
+        // The whole point of the fallback: a half-written or hand-edited
+        // file should cost the user their preference, not their app.
+        let dir = TempDir::new("corrupt");
+        let path = dir.join("settings.json");
+        std::fs::write(&path, b"{\"theme\": ").expect("write corrupt file");
+
+        assert_eq!(read_from(&path).theme, Theme::System);
+
+        // And the next save repairs it.
+        write_to(&path, &Settings { theme: Theme::Dark }).expect("overwrite");
+        assert_eq!(read_from(&path).theme, Theme::Dark);
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,0 +1,146 @@
+//! User preferences, stored as JSON beside the app's other config.
+//!
+//! Deliberately tiny and deliberately not in the webview's localStorage:
+//! a preference the user set should survive a cache clear, and it should
+//! be a file they can read, edit, or delete when something goes wrong.
+//!
+//! Everything here degrades to defaults rather than failing. A settings
+//! file that cannot be read is a worse reason to refuse to start than
+//! almost anything else the app could hit.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use tauri::Manager;
+
+use crate::error::{AppError, Result};
+
+/// Which appearance the user asked for.
+///
+/// `System` is not the same as recording whatever the system currently
+/// says: it means "keep following it", so a user who never chose still
+/// tracks the OS when they flip it at sunset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Theme {
+    #[default]
+    System,
+    Light,
+    Dark,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct Settings {
+    pub theme: Theme,
+}
+
+fn settings_path(app: &tauri::AppHandle) -> Result<PathBuf> {
+    let dir = app
+        .path()
+        .app_config_dir()
+        .map_err(|e| AppError::Settings(format!("no config directory: {e}")))?;
+    Ok(dir.join("settings.json"))
+}
+
+/// Reads the settings file, falling back to defaults.
+///
+/// A missing file is the normal first-run case. A corrupt one is not,
+/// but refusing to start over it would be worse than quietly using
+/// defaults — the user can always delete the file, and the next save
+/// rewrites it.
+pub fn load(app: &tauri::AppHandle) -> Settings {
+    let Ok(path) = settings_path(app) else {
+        return Settings::default();
+    };
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return Settings::default();
+    };
+    parse(&text)
+}
+
+/// Split from `load` so the fallback behaviour can be tested without a
+/// Tauri app handle or a real config directory.
+pub(crate) fn parse(text: &str) -> Settings {
+    serde_json::from_str(text).unwrap_or_default()
+}
+
+/// Writes the settings file, creating its directory if needed.
+///
+/// Written to a temporary file and renamed, so an interrupted write
+/// leaves the previous settings intact rather than a truncated file that
+/// reads as corrupt on next launch.
+pub fn save(app: &tauri::AppHandle, settings: &Settings) -> Result<()> {
+    let path = settings_path(app)?;
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)
+            .map_err(|e| AppError::Settings(format!("create {}: {e}", dir.display())))?;
+    }
+
+    let json = serde_json::to_string_pretty(settings)
+        .map_err(|e| AppError::Settings(format!("serialise settings: {e}")))?;
+
+    let temp = path.with_extension("json.tmp");
+    std::fs::write(&temp, json.as_bytes())
+        .map_err(|e| AppError::Settings(format!("write {}: {e}", temp.display())))?;
+    std::fs::rename(&temp, &path)
+        .map_err(|e| AppError::Settings(format!("replace {}: {e}", path.display())))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn theme_round_trips_as_a_lowercase_string() {
+        // The frontend compares against these spellings; a change here
+        // silently stops the preference applying.
+        assert_eq!(serde_json::to_string(&Theme::Dark).unwrap(), "\"dark\"");
+        assert_eq!(serde_json::to_string(&Theme::System).unwrap(), "\"system\"");
+        assert_eq!(
+            serde_json::from_str::<Theme>("\"light\"").unwrap(),
+            Theme::Light
+        );
+    }
+
+    #[test]
+    fn settings_serialise_with_the_key_the_frontend_reads() {
+        let json = serde_json::to_string(&Settings { theme: Theme::Dark }).unwrap();
+        assert_eq!(json, r#"{"theme":"dark"}"#);
+    }
+
+    #[test]
+    fn a_missing_file_reads_as_following_the_system() {
+        // First run. Not an error, and not a guess at the user's taste.
+        assert_eq!(Settings::default().theme, Theme::System);
+    }
+
+    #[test]
+    fn a_corrupt_file_falls_back_rather_than_failing() {
+        // Better to start with defaults than to refuse to open because a
+        // preferences file got truncated.
+        assert_eq!(parse("{not json").theme, Theme::System);
+        assert_eq!(parse("").theme, Theme::System);
+    }
+
+    #[test]
+    fn an_unknown_theme_falls_back_rather_than_failing() {
+        // A file written by a newer build, or edited by hand.
+        assert_eq!(parse(r#"{"theme":"solarized"}"#).theme, Theme::System);
+    }
+
+    #[test]
+    fn a_file_missing_the_key_still_parses() {
+        // `#[serde(default)]` on the struct: an older file, or one the
+        // user trimmed, should not be treated as corrupt.
+        assert_eq!(parse("{}").theme, Theme::System);
+    }
+
+    #[test]
+    fn a_valid_file_is_honoured() {
+        assert_eq!(parse(r#"{"theme":"dark"}"#).theme, Theme::Dark);
+        assert_eq!(parse(r#"{"theme":"light"}"#).theme, Theme::Light);
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { Crds } from "./pages/Crds";
 import { KindBrowser } from "./pages/KindBrowser";
 import { Helm } from "./pages/Helm";
 import { api, type ClusterInfo } from "./lib/api";
+import { applyTheme, isDark, parseTheme, type Theme } from "./lib/theme";
 
 export default function App() {
   const [cluster, setCluster] = useState<ClusterInfo | null>(null);
@@ -19,7 +20,38 @@ export default function App() {
   // connected". Without it the picker flashes on every launch.
   const [ready, setReady] = useState(false);
 
+  // App owns the appearance: the picker sets it, the OS feeds into it
+  // when the preference is "system", and one effect applies the result.
+  const [theme, setTheme] = useState<Theme>("system");
+
   const queryClient = useQueryClient();
+
+  useEffect(() => {
+    api
+      .getSettings()
+      .then((s) => setTheme(parseTheme(s.theme)))
+      // No settings file yet, or no bridge in browser dev. Following the
+      // system is the right fallback either way.
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    const system = window.matchMedia("(prefers-color-scheme: dark)");
+    const paint = () => applyTheme(isDark(theme, system.matches));
+    paint();
+    // Kept subscribed even when the preference is explicit: the user can
+    // switch back to "system" without a reload, and re-subscribing on
+    // every change would be the same work.
+    system.addEventListener("change", paint);
+    return () => system.removeEventListener("change", paint);
+  }, [theme]);
+
+  async function chooseTheme(next: Theme) {
+    // Applied first: the click should feel instant, and a preference
+    // that fails to persist is still the one the user asked for.
+    setTheme(next);
+    await api.setTheme(next).catch(() => {});
+  }
 
   useEffect(() => {
     // The session lives in Rust, so a webview reload reconnects to the
@@ -71,6 +103,8 @@ export default function App() {
         cluster={cluster}
         view={view}
         onSelect={setView}
+        theme={theme}
+        onThemeChange={chooseTheme}
         onSwitchCluster={() => setSwitching(true)}
         onDisconnect={disconnect}
       />

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -58,6 +58,8 @@ function setup({
         cluster={cluster}
         view={view}
         onSelect={onSelect}
+        theme="system"
+        onThemeChange={vi.fn()}
         onSwitchCluster={vi.fn()}
         onDisconnect={vi.fn()}
       />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,6 +3,8 @@ import { useQuery } from "@tanstack/react-query";
 import { Logo } from "./Logo";
 import { dragRegionProps } from "../lib/window";
 import { KIND_SECTIONS, type KindEntry } from "../lib/kinds";
+import { ThemePicker } from "./ThemePicker";
+import type { Theme } from "../lib/theme";
 import { api, type ApiResourceInfo, type ClusterInfo } from "../lib/api";
 
 /// Which pane the main area is showing.
@@ -38,6 +40,8 @@ interface SidebarProps {
   cluster: ClusterInfo | null;
   view: View;
   onSelect: (v: View) => void;
+  theme: Theme;
+  onThemeChange: (theme: Theme) => void;
   onSwitchCluster: () => void;
   onDisconnect: () => void;
 }
@@ -245,6 +249,8 @@ export function Sidebar({
   cluster,
   view,
   onSelect,
+  theme,
+  onThemeChange,
   onSwitchCluster,
   onDisconnect,
 }: SidebarProps) {
@@ -308,6 +314,10 @@ export function Sidebar({
           onSelect={() => onSelect({ type: "helm" })}
         />
       </nav>
+
+      <div className="border-t p-2">
+        <ThemePicker theme={theme} onChange={onThemeChange} />
+      </div>
 
       {cluster && (
         <div className="border-t p-2">

--- a/src/components/ThemePicker.test.tsx
+++ b/src/components/ThemePicker.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemePicker } from "./ThemePicker";
+
+describe("ThemePicker", () => {
+  it("offers the three modes and marks the current one", () => {
+    render(<ThemePicker theme="dark" onChange={vi.fn()} />);
+
+    const options = screen.getAllByRole("radio");
+    expect(options.map((o) => o.textContent)).toEqual([
+      "System",
+      "Light",
+      "Dark",
+    ]);
+    expect(screen.getByRole("radio", { name: "Dark" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "System" })).not.toBeChecked();
+  });
+
+  it("reports the mode that was clicked", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<ThemePicker theme="system" onChange={onChange} />);
+
+    await user.click(screen.getByRole("radio", { name: "Light" }));
+    expect(onChange).toHaveBeenCalledWith("light");
+  });
+
+  it("is a labelled group, so it reads as one control", () => {
+    // Three loose buttons announce as three unrelated controls; a
+    // radiogroup announces as one choice with three options.
+    render(<ThemePicker theme="system" onChange={vi.fn()} />);
+    expect(
+      screen.getByRole("radiogroup", { name: "Appearance" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/ThemePicker.tsx
+++ b/src/components/ThemePicker.tsx
@@ -1,0 +1,40 @@
+import { THEMES, type Theme } from "../lib/theme";
+
+// Three segments rather than a dropdown: there are exactly three
+// choices, they never grow, and a segmented control shows the current
+// one without being opened.
+
+export function ThemePicker({
+  theme,
+  onChange,
+}: {
+  theme: Theme;
+  onChange: (theme: Theme) => void;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Appearance"
+      className="flex gap-0.5 rounded-sm bg-content/[0.04] p-0.5"
+    >
+      {THEMES.map((option) => {
+        const active = option.id === theme;
+        return (
+          <button
+            key={option.id}
+            role="radio"
+            aria-checked={active}
+            onClick={() => onChange(option.id)}
+            className={`flex-1 rounded-[3px] px-1.5 py-0.5 text-2xs transition-colors duration-150 ease-swift ${
+              active
+                ? "bg-content/[0.10] font-medium text-content"
+                : "text-content-muted hover:text-content-secondary"
+            }`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/dev/fixtures.ts
+++ b/src/dev/fixtures.ts
@@ -476,6 +476,10 @@ const FIXTURES: Record<string, unknown> = {
       { key: "NodeHosts", bytes: 34, binary: false, value: "198.19.249.2 orbstack\n" },
     ],
   },
+  // Browser dev has no config directory; following the system is the
+  // same fallback the app uses when the file is missing.
+  get_settings: { theme: "system" },
+  set_theme: { theme: "system" },
   disconnect: null,
   // A browser has no native window to make translucent. Without this
   // the fallback `[]` would apply, and an empty array is truthy.

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,6 +4,7 @@
 // serialises camelCase so the two stay aligned without a translation
 // layer. When a command signature changes there, it changes here.
 import { Channel, invoke } from "@tauri-apps/api/core";
+import type { Theme } from "./theme";
 
 export interface ContextInfo {
   name: string;
@@ -265,6 +266,13 @@ export interface ObjectDetail extends Editable {
   yaml: string;
 }
 
+/// Persisted user preferences. Stored as JSON in the app's config
+/// directory by the Rust side, not in the webview — a preference should
+/// survive a cache clear and be a file the user can read or delete.
+export interface Settings {
+  theme: Theme;
+}
+
 /// Identifies the object an editor is open on. Sent back with the edit
 /// so the backend can refuse one that has been retargeted.
 export interface EditTarget {
@@ -421,6 +429,9 @@ export const api = {
   startPodLogs: (options: LogOptions, channel: Channel<LogEvent>) =>
     invoke<number>("start_pod_logs", { options, channel }),
   stopPodLogs: (id: number) => invoke<boolean>("stop_pod_logs", { id }),
+
+  getSettings: () => invoke<Settings>("get_settings"),
+  setTheme: (theme: Theme) => invoke<Settings>("set_theme", { theme }),
 
   /// Whether native window vibrancy actually took effect. Asked rather
   /// than inferred from the platform: support depends on OS build and,

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { applyTheme, isDark, parseTheme } from "./theme";
+
+// The preference and the resolved appearance are separate on purpose.
+// Storing the resolved value would freeze a user who chose "system" into
+// whichever mode they happened to be in at the time.
+
+describe("isDark", () => {
+  it("honours an explicit choice whatever the OS says", () => {
+    expect(isDark("dark", false)).toBe(true);
+    expect(isDark("light", true)).toBe(false);
+  });
+
+  it("follows the OS when the preference is system", () => {
+    expect(isDark("system", true)).toBe(true);
+    expect(isDark("system", false)).toBe(false);
+  });
+});
+
+describe("parseTheme", () => {
+  it("accepts the three it knows", () => {
+    expect(parseTheme("light")).toBe("light");
+    expect(parseTheme("dark")).toBe("dark");
+    expect(parseTheme("system")).toBe("system");
+  });
+
+  it("falls back to system for anything else", () => {
+    // A settings file from a newer build, hand-edited, or truncated.
+    // Leaving the app with no appearance at all would be worse than
+    // ignoring the value.
+    expect(parseTheme("solarized")).toBe("system");
+    expect(parseTheme(undefined)).toBe("system");
+    expect(parseTheme(null)).toBe("system");
+    expect(parseTheme(42)).toBe("system");
+  });
+});
+
+describe("applyTheme", () => {
+  it("toggles the class Tailwind switches on", () => {
+    const root = document.createElement("html");
+    applyTheme(true, root);
+    expect(root.classList.contains("dark")).toBe(true);
+    applyTheme(false, root);
+    expect(root.classList.contains("dark")).toBe(false);
+  });
+
+  it("sets color-scheme so native controls match", () => {
+    // Scrollbars and form controls come from the engine, not from our
+    // stylesheet — without this they stay light on a dark window.
+    const root = document.createElement("html");
+    applyTheme(true, root);
+    expect(root.style.colorScheme).toBe("dark");
+    applyTheme(false, root);
+    expect(root.style.colorScheme).toBe("light");
+  });
+});

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,39 @@
+// Appearance: what the user asked for, and what that means right now.
+//
+// Two separate things, deliberately. `Theme` is the preference and is
+// what gets persisted; `system` is a live fact about the OS. Storing the
+// *resolved* value instead would freeze a user who chose "system" into
+// whichever mode they happened to be in when they chose it.
+
+export type Theme = "system" | "light" | "dark";
+
+export const THEMES: { id: Theme; label: string }[] = [
+  { id: "system", label: "System" },
+  { id: "light", label: "Light" },
+  { id: "dark", label: "Dark" },
+];
+
+/// Whether the given preference means dark, given what the OS says.
+export function isDark(theme: Theme, systemPrefersDark: boolean): boolean {
+  if (theme === "dark") return true;
+  if (theme === "light") return false;
+  return systemPrefersDark;
+}
+
+/// Anything unrecognised means "follow the system" — a settings file
+/// written by a newer build, or edited by hand, should not leave the app
+/// with no appearance at all.
+export function parseTheme(value: unknown): Theme {
+  return value === "light" || value === "dark" || value === "system"
+    ? value
+    : "system";
+}
+
+/// Tailwind runs with darkMode:"class", so the class on <html> is what
+/// actually switches the palette.
+export function applyTheme(dark: boolean, root: HTMLElement = document.documentElement) {
+  root.classList.toggle("dark", dark);
+  // Tells the engine which built-in control colours to use — form
+  // controls and scrollbars come from here, not from our stylesheet.
+  root.style.colorScheme = dark ? "dark" : "light";
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
 import { api } from "./lib/api";
+import { applyTheme } from "./lib/theme";
 import "./index.css";
 
 // Opening the Vite dev server in a plain browser has no Tauri bridge,
@@ -14,14 +15,11 @@ if (import.meta.env.DEV && !("__TAURI_INTERNALS__" in window)) {
   installDemoBridge();
 }
 
-// Follow the OS appearance. Tailwind runs with darkMode:"class", so the
-// class on <html> is what actually switches the palette.
-const dark = window.matchMedia("(prefers-color-scheme: dark)");
-const applyTheme = (isDark: boolean) =>
-  document.documentElement.classList.toggle("dark", isDark);
-
-applyTheme(dark.matches);
-dark.addEventListener("change", (e) => applyTheme(e.matches));
+// Paint in the OS appearance immediately, before the first render, so
+// the window never flashes the wrong palette. The stored preference is
+// read asynchronously and applied by App — which owns it from then on,
+// because two places toggling the class would drift apart.
+applyTheme(window.matchMedia("(prefers-color-scheme: dark)").matches);
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -49,6 +49,12 @@
   --ambient-2: 14 165 233;
   --ambient-alpha: 0.05;
 
+  /* How much of the window's own background survives when the OS is
+     blurring the desktop behind us. Not zero: a translucent window still
+     has to be a readable one, and the desktop behind it is a colour we
+     do not control. */
+  --scrim-alpha: 0.9;
+
   /* Code surfaces — the YAML pane and the log viewer.
    *
    * These get their own ramp rather than reusing the surface tokens. A
@@ -100,6 +106,8 @@
 
   --ambient-alpha: 0.1;
 
+  --scrim-alpha: 0.94;
+
   --code-bg: 6 8 12;
   --code-fg: 203 213 225;
   --code-gutter: 71 85 105;
@@ -124,6 +132,15 @@
   --surface-1: var(--glass-bg);
 }
 
+/* Translucent, not transparent. A fully transparent body leaves the
+ * content sitting directly on the blurred desktop, and dark mode's text
+ * is light grey — over anything bright it disappears. The scrim keeps
+ * the window's own surface underneath everything, so contrast holds
+ * whatever the user's wallpaper is doing, and the vibrancy reads as
+ * depth rather than as a missing background.
+ *
+ * The glass chrome composites on top of this, so fixing it here fixes
+ * the sidebar and headers too. */
 .vibrancy body {
-  background: transparent;
+  background-color: rgb(var(--base) / var(--scrim-alpha));
 }


### PR DESCRIPTION
## The bug

Dark mode was unreadable whenever native vibrancy was active. One line
caused it:

```css
.vibrancy body { background: transparent; }
```

Transparent is not translucent. That removed the window's own surface
entirely, so content sat directly on the blurred desktop — and dark
mode's text is light grey. Over anything bright, contrast collapsed:
section labels, table headers and row names disappeared.

Light mode survived because its text is dark, which is why this went
unnoticed.

Reproduced by adding the `vibrancy` class in the browser over a bright
backdrop, which matched the reported screenshots exactly.

## The fix

Vibrancy keeps a scrim: the base colour at `0.94` in dark, `0.9` in
light, behind a new `--scrim-alpha` token. Enough of the desktop still
shows through to read as depth, while contrast no longer depends on the
user's wallpaper. The glass chrome composites on top of it, so the
sidebar and headers are fixed by the same change.

## Theme preference

Appearance is now a choice rather than only a reading of the OS: light,
dark, or system, from a segmented control in the sidebar footer.

Persisted as JSON in the app's config directory rather than in the
webview — a preference should survive a cache clear and be a file the
user can read, edit or delete when something goes wrong. "System"
stores the *intent to follow*, not a snapshot of the current mode, so it
keeps tracking the OS when it flips at sunset.

Settings degrade rather than fail. A missing file is first run; a
corrupt or hand-edited one falls back to following the system instead of
refusing to start. Writes go through a temp file and a rename, so an
interrupted save leaves the previous preferences intact.

## Tests

93 Rust and 69 frontend. New coverage for the settings fallbacks
(missing, corrupt, unknown value, missing key), the preference/resolved
split, and the picker.

## What I could not verify

The scrim fix is verified in the browser: `body` goes from `transparent`
to `rgba(9, 11, 16, 0.94)` and the pane renders dark and readable. But
vibrancy itself is a native effect, so **the real check is `pnpm tauri
dev` on macOS** — the preview browser cannot apply `NSVisualEffectView`.

If it still looks washed out there, the next knob is `--scrim-alpha` in
`src/styles/tokens.css`; and the material in `src-tauri/src/vibrancy.rs`
is `NSVisualEffectMaterial::Sidebar`, which is more translucent than
what a full-window backdrop usually wants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)