### PR TITLE
Release pipeline and Homebrew cask

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,16 @@ jobs:
           fi
           echo "All commits are signed off."
 
+  # The three manifests that carry a version drift silently, and the
+  # cost lands at release time when an installer is named after the
+  # wrong one. Checked on every PR so it never gets that far.
+  version:
+    name: Version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python3 scripts/version.py
+
   rust:
     name: Rust
     runs-on: ubuntu-latest
@@ -139,7 +149,7 @@ jobs:
   ci:
     name: ci
     if: always()
-    needs: [dco, rust, web]
+    needs: [dco, version, rust, web]
     runs-on: ubuntu-latest
     steps:
       - name: Check results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,230 @@
+name: release
+
+# Tag-driven. Pushing `v0.2.0` builds every platform, attaches the
+# installers to a draft GitHub release, and publishes it once they have
+# all landed — so a release is never half-visible while Windows is still
+# compiling.
+#
+#   scripts/version.py --set 0.2.0
+#   git commit -sam "release: 0.2.0" && git tag v0.2.0 && git push --follow-tags
+#
+# See RELEASING.md for what needs to be true before that, and which
+# secrets turn signing on.
+
+on:
+  push:
+    tags: ["v*"]
+  # Lets a failed run be retried without moving the tag.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to build (e.g. v0.2.0)"
+        required: true
+
+permissions:
+  contents: write
+
+env:
+  NODE_VERSION: "22"
+  PNPM_VERSION: "10"
+
+jobs:
+  # A tag whose manifests say a different version produces installers
+  # named after the manifest, not the tag — and a Homebrew cask that
+  # 404s. Cheap to check, miserable to discover afterwards.
+  version:
+    name: Version
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - id: resolve
+        run: |
+          tag="${{ inputs.tag || github.ref_name }}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          python3 scripts/version.py --check "$tag"
+
+  # One draft up front, so the matrix uploads into it rather than racing
+  # to create it.
+  draft:
+    name: Draft release
+    needs: version
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create.outputs.result }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version.outputs.tag }}
+
+      - id: create
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = "${{ needs.version.outputs.tag }}";
+            const { owner, repo } = context.repo;
+
+            // Reuse the draft if this is a retry, rather than stacking
+            // up a second release for the same tag.
+            const releases = await github.rest.repos.listReleases({ owner, repo, per_page: 100 });
+            const existing = releases.data.find((r) => r.tag_name === tag && r.draft);
+            if (existing) {
+              core.info(`reusing draft ${existing.id}`);
+              return existing.id;
+            }
+
+            const created = await github.rest.repos.createRelease({
+              owner, repo,
+              tag_name: tag,
+              name: `Loupe ${tag}`,
+              draft: true,
+              generate_release_notes: true,
+            });
+            return created.data.id;
+          result-encoding: string
+
+  build:
+    name: ${{ matrix.label }}
+    needs: [version, draft]
+    strategy:
+      # One platform failing should not cancel installers that already
+      # built — the draft keeps whatever landed and the run can be
+      # retried for the rest.
+      fail-fast: false
+      matrix:
+        include:
+          - label: macOS (Apple Silicon)
+            os: macos-latest
+            target: aarch64-apple-darwin
+            args: "--target aarch64-apple-darwin"
+          - label: macOS (Intel)
+            os: macos-latest
+            target: x86_64-apple-darwin
+            args: "--target x86_64-apple-darwin"
+          # Built on the oldest runner we support so the binary does not
+          # pick up a glibc newer than the distros people actually run.
+          - label: Linux (x86_64)
+            os: ubuntu-22.04
+            target: ""
+            args: ""
+          - label: Windows (x86_64)
+            os: windows-latest
+            target: ""
+            args: ""
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version.outputs.tag }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          # Empty for the native builds; the macOS jobs cross-compile,
+          # and the Intel one is a cross-compile on an Arm runner.
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          key: ${{ matrix.target }}
+
+      - name: Install system dependencies
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev \
+            librsvg2-dev patchelf libglib2.0-dev
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # macOS signing and notarisation. All absent on a fork or
+          # before the certificates exist, and Tauri then produces an
+          # unsigned bundle rather than failing — see RELEASING.md for
+          # what that costs the people installing it.
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        with:
+          releaseId: ${{ needs.draft.outputs.release_id }}
+          args: ${{ matrix.args }}
+
+  publish:
+    name: Publish
+    needs: [version, draft, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const release_id = Number("${{ needs.draft.outputs.release_id }}");
+
+            const assets = await github.rest.repos.listReleaseAssets({ owner, repo, release_id });
+            const names = assets.data.map((a) => a.name);
+            core.info(`assets:\n  ${names.join("\n  ")}`);
+
+            // Publishing a release that is missing a platform is worse
+            // than failing here: the tag looks complete and the gap is
+            // only found by whoever tried to download it.
+            const expected = [/\.dmg$/, /\.AppImage$/, /\.deb$/, /-setup\.exe$/, /\.msi$/];
+            const missing = expected.filter((p) => !names.some((n) => p.test(n)));
+            if (missing.length) {
+              core.setFailed(`no asset matching: ${missing.join(", ")}`);
+              return;
+            }
+
+            await github.rest.repos.updateRelease({
+              owner, repo, release_id,
+              draft: false,
+              make_latest: "true",
+            });
+            core.info("published");
+
+  # Updates the Homebrew tap so `brew upgrade` sees the new version.
+  # Skipped when the token is absent, which is the state until the tap
+  # repository exists.
+  homebrew:
+    name: Homebrew tap
+    needs: [version, publish]
+    runs-on: ubuntu-latest
+    # The `secrets` context is not available in a step's `if`, so the
+    # token is lifted into the environment and tested from there.
+    env:
+      GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      VERSION: ${{ needs.version.outputs.version }}
+      TAG: ${{ needs.version.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version.outputs.tag }}
+
+      - name: Update the cask
+        if: env.GH_TOKEN != ''
+        run: scripts/update-homebrew-tap.sh
+
+      - name: Explain the skip
+        if: env.GH_TOKEN == ''
+        run: |
+          echo "::notice::HOMEBREW_TAP_TOKEN is not set — the tap was not updated."
+          echo "See RELEASING.md for how to create the tap and the token."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,13 +155,21 @@ jobs:
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # macOS signing and notarisation. All absent on a fork or
-          # before the certificates exist, and Tauri then produces an
-          # unsigned bundle rather than failing — see RELEASING.md for
-          # what that costs the people installing it.
+          # macOS signing and notarisation. The six secrets go together;
+          # with all of them Tauri signs with the real identity and
+          # notarises, and with none of them it falls back to "-".
+          #
+          # That fallback matters more than it looks. Left to itself
+          # Tauri does not codesign the bundle at all, and the only
+          # signature is the linker's — which macOS reads as *malformed*
+          # and reports as "Loupe is damaged and can't be opened",
+          # pointing the user at a corrupt download rather than at an
+          # unsigned app. An explicit ad-hoc identity produces a valid
+          # signature with the hardened runtime, so the app is refused
+          # for the reason it actually is: not notarised.
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,10 @@ jobs:
     # The `secrets` context is not available in a step's `if`, so the
     # token is lifted into the environment and tested from there.
     env:
-      GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      # Reading this repository's release assets is the workflow's own
+      # business; only the push to the tap needs the extra token.
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       VERSION: ${{ needs.version.outputs.version }}
       TAG: ${{ needs.version.outputs.tag }}
     steps:
@@ -228,11 +231,11 @@ jobs:
           ref: ${{ needs.version.outputs.tag }}
 
       - name: Update the cask
-        if: env.GH_TOKEN != ''
+        if: env.TAP_TOKEN != ''
         run: scripts/update-homebrew-tap.sh
 
       - name: Explain the skip
-        if: env.GH_TOKEN == ''
+        if: env.TAP_TOKEN == ''
         run: |
           echo "::notice::HOMEBREW_TAP_TOKEN is not set — the tap was not updated."
           echo "See RELEASING.md for how to create the tap and the token."

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ and the error is surfaced rather than swallowed into an empty table.
 brew install --cask kryptonhq/tap/loupe
 ```
 
+Loupe is not notarised by Apple yet, so macOS blocks the first launch.
+Allow it once under **System Settings → Privacy & Security → Open
+Anyway**, or install with `--no-quarantine`.
+
 Or take a build from [releases](https://github.com/kryptonhq/loupe/releases):
 
 | Platform | Download |

--- a/README.md
+++ b/README.md
@@ -105,7 +105,25 @@ your kubeconfig says you are, so the API server decides what you can see.
 If a listing comes back denied, that is your RBAC — not a bug in the app,
 and the error is surfaced rather than swallowed into an empty table.
 
-## Getting started
+## Installing
+
+```bash
+brew install --cask kryptonhq/tap/loupe
+```
+
+Or take a build from [releases](https://github.com/kryptonhq/loupe/releases):
+
+| Platform | Download |
+| --- | --- |
+| macOS (Apple Silicon) | `Loupe_<version>_aarch64.dmg` |
+| macOS (Intel) | `Loupe_<version>_x64.dmg` |
+| Linux | `.AppImage` (portable) or `.deb` |
+| Windows | `-setup.exe` or `.msi` |
+
+Loupe reads the same kubeconfig as `kubectl`, so there is nothing to
+configure — it lists the contexts you already have.
+
+## Building from source
 
 Prerequisites: [Rust](https://rustup.rs), Node 22+, pnpm 10+. On macOS
 you also need the Xcode command line tools.
@@ -167,6 +185,11 @@ src-tauri/
 
 The frontend mirrors the runtime's operator UI — same Tailwind theme,
 same mark — so the two read as one product.
+
+## Releasing
+
+Tag-driven, built by GitHub Actions, published as a GitHub release. See
+[RELEASING.md](RELEASING.md).
 
 ## Contributing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -136,11 +136,42 @@ To set it up:
 
 1. Create a **public** repository named exactly `homebrew-tap` under the
    `kryptonhq` organisation. The `homebrew-` prefix is what lets
-   `kryptonhq/tap` resolve. It may be empty — the first release creates
-   the branch and the `Casks/` directory.
-2. Create a fine-grained personal access token scoped to that repository
-   with **Contents: read and write**.
-3. Add it to this repository as the `HOMEBREW_TAP_TOKEN` secret.
+   `kryptonhq/tap` resolve.
+
+   Nothing needs to be committed to it — the first release creates the
+   branch and `Casks/loupe.rb`. A README is worth adding so the
+   repository is not blank to anyone who lands on it.
+
+2. Create the token at
+   **[Settings → Developer settings → Personal access tokens → Fine-grained tokens](https://github.com/settings/personal-access-tokens/new)**:
+
+   | Field | Value |
+   | --- | --- |
+   | Resource owner | `kryptonhq` — the organisation, *not* your personal account |
+   | Repository access | Only select repositories → `homebrew-tap` |
+   | Repository permissions | **Contents: Read and write** |
+   | Expiration | Whatever you will remember to rotate |
+
+   Two things catch people out. The resource owner must be the
+   organisation, or the token is issued against your personal account
+   and cannot see an org repository at all. And organisations can block
+   fine-grained tokens entirely — if the token appears to have no
+   access, check **Organisation settings → Personal access tokens** and
+   allow them.
+
+   A [deploy key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys)
+   on the tap with write access is the alternative worth knowing about:
+   it never expires and belongs to the repository rather than to a
+   person, so it does not break when someone leaves. It needs the script
+   switched to SSH, which is a small change if the expiry becomes
+   annoying.
+
+3. Add the token to **this** repository as the `HOMEBREW_TAP_TOKEN`
+   secret (Settings → Secrets and variables → Actions).
+
+The token is only used to push to the tap. Reading this repository's
+release assets uses the workflow's own `GITHUB_TOKEN`, so the tap token
+never needs access here.
 
 The release workflow then renders
 [`packaging/homebrew/loupe.rb.template`](packaging/homebrew/loupe.rb.template)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,130 @@
+# Releasing
+
+Releases are cut from a tag and built by
+[`.github/workflows/release.yml`](.github/workflows/release.yml). Every
+platform builds into one draft GitHub release, which is published only
+once all of them have landed.
+
+## Cutting a release
+
+```bash
+scripts/version.py --set 0.2.0        # package.json, Cargo.toml, tauri.conf.json
+pnpm install                          # refresh the lockfile's version
+git commit -sam "release: 0.2.0"
+git tag v0.2.0
+git push --follow-tags
+```
+
+The workflow refuses a tag whose manifests disagree with it, because the
+installer is named from the manifest rather than the tag — a mismatch
+produces a `Loupe_0.1.0_aarch64.dmg` inside a `v0.2.0` release, and a
+Homebrew cask that 404s.
+
+A failed run can be retried from the Actions tab (**Run workflow** →
+enter the tag) without moving or recreating the tag.
+
+## What gets built
+
+| Platform | Artifacts |
+| --- | --- |
+| macOS (Apple Silicon) | `Loupe_<version>_aarch64.dmg` |
+| macOS (Intel) | `Loupe_<version>_x64.dmg` |
+| Linux | `.AppImage`, `.deb`, `.rpm` |
+| Windows | `.msi`, `-setup.exe` (NSIS) |
+
+Linux builds on `ubuntu-22.04` rather than the newest runner: the binary
+picks up the glibc it was built against, and building on 24.04 would
+refuse to start on anything older.
+
+The two macOS builds are separate rather than a universal binary, so
+each download is the size of one architecture. Homebrew picks the right
+one from the cask's `arch` stanza.
+
+## Signing
+
+Everything below is optional in the sense that the build succeeds
+without it. None of it is optional if you want people to be able to open
+the app without a fight.
+
+### macOS
+
+Unsigned and un-notarised, macOS refuses to open the app at all —
+Gatekeeper reports it as damaged, and the only way past is
+`xattr -d com.apple.quarantine`, which is not something to ask of
+someone installing a Kubernetes client.
+
+It also rules out Homebrew: casks
+[must not require Gatekeeper to be bypassed](https://docs.brew.sh/Acceptable-Casks).
+
+Signing needs an Apple Developer account (99 USD/year) and these
+repository secrets:
+
+| Secret | What it is |
+| --- | --- |
+| `APPLE_CERTIFICATE` | Developer ID Application `.p12`, base64 encoded |
+| `APPLE_CERTIFICATE_PASSWORD` | The password for that `.p12` |
+| `APPLE_SIGNING_IDENTITY` | e.g. `Developer ID Application: Name (TEAMID)` |
+| `APPLE_ID` | The Apple ID used for notarisation |
+| `APPLE_PASSWORD` | An app-specific password, not the account password |
+| `APPLE_TEAM_ID` | The 10-character team identifier |
+
+```bash
+# Export the certificate from Keychain Access first.
+base64 -i DeveloperID.p12 | pbcopy
+```
+
+When they are all present Tauri signs and notarises; when any is absent
+it builds unsigned and says so in the log.
+
+### Windows
+
+Unsigned installers work, but SmartScreen warns until the binary has
+built up reputation — which for a low-volume download effectively means
+always. Signing needs a code-signing certificate and a
+`bundle.windows.signCommand` in `tauri.conf.json`; there is no
+credential-only path.
+
+## Homebrew
+
+```bash
+brew install --cask kryptonhq/tap/loupe
+```
+
+### The tap
+
+The cask lives in a tap this project owns —
+`github.com/kryptonhq/homebrew-tap` — rather than in `homebrew/cask`.
+That is the right starting point: a tap can be created today and needs
+nobody's approval, while homebrew-cask judges submissions on
+[notability](https://docs.brew.sh/Acceptable-Casks) and will decline a
+project that has not built an audience yet. Moving to homebrew-cask
+later is a submission, not a migration — the tap can keep working
+alongside it.
+
+To set it up:
+
+1. Create a **public** repository named exactly `homebrew-tap` under the
+   `kryptonhq` organisation. The `homebrew-` prefix is what lets
+   `kryptonhq/tap` resolve.
+2. Create a fine-grained personal access token scoped to that repository
+   with **Contents: read and write**.
+3. Add it to this repository as the `HOMEBREW_TAP_TOKEN` secret.
+
+The release workflow then renders
+[`packaging/homebrew/loupe.rb.template`](packaging/homebrew/loupe.rb.template)
+with the published DMGs' checksums and pushes it to `Casks/loupe.rb`.
+Without the secret that job logs a notice and skips, so releases work
+before the tap exists.
+
+Checksums are taken from the uploaded artifacts rather than from a local
+build, so what the cask claims is what people actually download.
+
+## Not done yet
+
+- **Auto-update.** Tauri ships an updater; it needs a signing key pair
+  and an update manifest published alongside the release. Worth having
+  before there are enough users that "download the new DMG" stops being
+  reasonable.
+- **Linux repositories.** The `.deb` is a direct download, not an apt
+  repository. AppImage covers most of the gap.
+- **`homebrew/cask` submission**, once the notability bar is met.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -48,16 +48,35 @@ the app without a fight.
 
 ### macOS
 
-Unsigned and un-notarised, macOS refuses to open the app at all —
-Gatekeeper reports it as damaged, and the only way past is
-`xattr -d com.apple.quarantine`, which is not something to ask of
-someone installing a Kubernetes client.
+There are three states, not two, and the difference between the first
+two is worth understanding before deciding what to do about the third.
 
-It also rules out Homebrew: casks
+**Left alone**, Tauri does not codesign the bundle at all. The only
+signature is the one the linker leaves on the binary, which macOS reads
+as *malformed* — `spctl` reports "code has no resources but signature
+indicates they must be present", and the user is told **"Loupe is
+damaged and can't be opened. You should move it to the Trash."** That
+message is actively misleading: it points at a corrupt download rather
+than at an unsigned app, and there is no obvious way past it.
+
+**Ad-hoc signed**, which is what the release workflow does when no
+certificate is configured, the bundle carries a valid signature and the
+hardened runtime. Gatekeeper still refuses it — there is no
+notarisation — but for the reason it actually is, and the user gets the
+normal "Open Anyway" path in Privacy & Security. This costs nothing and
+is the current default.
+
+**Signed and notarised** is the only state where the app opens on a
+double-click, and the only one homebrew/cask would accept, since a cask
+there
 [must not require Gatekeeper to be bypassed](https://docs.brew.sh/Acceptable-Casks).
+Our own tap has no such rule, so the cask ships today with a `caveats`
+block that explains the situation rather than a `postflight` that strips
+the quarantine attribute silently.
 
-Signing needs an Apple Developer account (99 USD/year) and these
-repository secrets:
+Getting there needs an Apple Developer account (99 USD/year) and these
+repository secrets. They are all-or-nothing: a partial set makes Tauri
+attempt a notarisation it cannot complete.
 
 | Secret | What it is |
 | --- | --- |
@@ -73,8 +92,9 @@ repository secrets:
 base64 -i DeveloperID.p12 | pbcopy
 ```
 
-When they are all present Tauri signs and notarises; when any is absent
-it builds unsigned and says so in the log.
+When they are all present Tauri signs with the real identity and
+notarises. When `APPLE_SIGNING_IDENTITY` is absent the workflow passes
+`-` instead, which is the ad-hoc case above.
 
 ### Windows
 
@@ -89,6 +109,17 @@ credential-only path.
 ```bash
 brew install --cask kryptonhq/tap/loupe
 ```
+
+Until the builds are notarised, first launch needs one of:
+
+- **System Settings → Privacy & Security → Open Anyway**, or
+- `brew install --cask --no-quarantine kryptonhq/tap/loupe`
+
+The cask says so in its caveats. It could remove the quarantine
+attribute itself in a `postflight` and make the whole thing invisible,
+and deliberately does not: stripping a security attribute on someone's
+behalf, without them asking, is not a decision an installer should make
+quietly.
 
 ### The tap
 
@@ -105,7 +136,8 @@ To set it up:
 
 1. Create a **public** repository named exactly `homebrew-tap` under the
    `kryptonhq` organisation. The `homebrew-` prefix is what lets
-   `kryptonhq/tap` resolve.
+   `kryptonhq/tap` resolve. It may be empty — the first release creates
+   the branch and the `Casks/` directory.
 2. Create a fine-grained personal access token scoped to that repository
    with **Contents: read and write**.
 3. Add it to this repository as the `HOMEBREW_TAP_TOKEN` secret.

--- a/packaging/homebrew/loupe.rb.template
+++ b/packaging/homebrew/loupe.rb.template
@@ -19,6 +19,26 @@ cask "loupe" do
 
   app "Loupe.app"
 
+  # Said plainly rather than worked around. Loupe is ad-hoc signed but
+  # not notarised, so Gatekeeper refuses it on first open. A cask can
+  # strip the quarantine attribute in a postflight and make that
+  # invisible — this one deliberately does not. Removing a security
+  # attribute on someone's behalf, without them asking, is not a
+  # decision an installer should make quietly.
+  caveats <<~EOS
+    Loupe is not yet notarised by Apple, so macOS will refuse to open it
+    the first time. Either allow it once:
+
+      System Settings -> Privacy & Security -> Open Anyway
+
+    or install without the quarantine attribute:
+
+      brew install --cask --no-quarantine #{token}
+
+    Notarised builds are planned; see
+    https://github.com/kryptonhq/loupe/blob/main/RELEASING.md
+  EOS
+
   # Everything Loupe writes, so `brew uninstall --zap` leaves nothing.
   # `settings.json` lives in the Application Support directory; the
   # kubeconfig does not belong to us and is deliberately not listed.

--- a/packaging/homebrew/loupe.rb.template
+++ b/packaging/homebrew/loupe.rb.template
@@ -1,0 +1,33 @@
+cask "loupe" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "__VERSION__"
+  sha256 arm:   "__SHA256_ARM__",
+         intel: "__SHA256_INTEL__"
+
+  url "https://github.com/kryptonhq/loupe/releases/download/v#{version}/Loupe_#{version}_#{arch}.dmg",
+      verified: "github.com/kryptonhq/loupe/"
+
+  name "Loupe"
+  desc "Open-source desktop client for Kubernetes"
+  homepage "https://github.com/kryptonhq/loupe"
+
+  # Matches `bundle.macOS.minimumSystemVersion` in tauri.conf.json, which
+  # is Tauri v2's own floor. If the two drift, Homebrew installs a build
+  # the Finder then refuses to open.
+  depends_on macos: ">= :catalina"
+
+  app "Loupe.app"
+
+  # Everything Loupe writes, so `brew uninstall --zap` leaves nothing.
+  # `settings.json` lives in the Application Support directory; the
+  # kubeconfig does not belong to us and is deliberately not listed.
+  zap trash: [
+    "~/Library/Application Support/ai.krypton.loupe",
+    "~/Library/Caches/ai.krypton.loupe",
+    "~/Library/HTTPStorages/ai.krypton.loupe",
+    "~/Library/Preferences/ai.krypton.loupe.plist",
+    "~/Library/Saved Application State/ai.krypton.loupe.savedState",
+    "~/Library/WebKit/ai.krypton.loupe",
+  ]
+end

--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -8,15 +8,26 @@
 # actually download — computing them from a local build would let a
 # re-upload drift from what the cask claims.
 #
-#   VERSION=0.2.0 TAG=v0.2.0 GH_TOKEN=... scripts/update-homebrew-tap.sh
+#   VERSION=0.2.0 TAG=v0.2.0 GH_TOKEN=... TAP_TOKEN=... \
+#     scripts/update-homebrew-tap.sh
 #
-# GH_TOKEN needs `contents: write` on the tap repository only.
+# Two tokens, because they are two different repositories:
+#
+#   GH_TOKEN   reads the release assets from this repository. In CI this
+#              is the workflow's own GITHUB_TOKEN.
+#   TAP_TOKEN  pushes to the tap. Needs `contents: write` there and
+#              nothing anywhere else.
+#
+# Using one token for both would mean granting the tap's token read
+# access here, or relying on this repository staying public — neither of
+# which should be load-bearing.
 
 set -euo pipefail
 
 : "${VERSION:?set VERSION, e.g. 0.2.0}"
 : "${TAG:?set TAG, e.g. v0.2.0}"
-: "${GH_TOKEN:?set GH_TOKEN with write access to the tap}"
+: "${GH_TOKEN:?set GH_TOKEN to read the release assets}"
+: "${TAP_TOKEN:?set TAP_TOKEN with write access to the tap}"
 
 REPO="${REPO:-kryptonhq/loupe}"
 TAP_REPO="${TAP_REPO:-kryptonhq/homebrew-tap}"
@@ -54,7 +65,7 @@ if grep -q "__" "$work/loupe.rb"; then
 fi
 
 echo "cloning $TAP_REPO"
-git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/${TAP_REPO}.git" "$work/tap"
+git clone --depth 1 "https://x-access-token:${TAP_TOKEN}@github.com/${TAP_REPO}.git" "$work/tap"
 
 mkdir -p "$work/tap/Casks"
 cp "$work/loupe.rb" "$work/tap/Casks/loupe.rb"

--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Renders the Homebrew cask for a published release and pushes it to the
+# tap repository.
+#
+# Run by the release workflow after the GitHub release goes public,
+# because the checksums have to come from the artifacts people will
+# actually download — computing them from a local build would let a
+# re-upload drift from what the cask claims.
+#
+#   VERSION=0.2.0 TAG=v0.2.0 GH_TOKEN=... scripts/update-homebrew-tap.sh
+#
+# GH_TOKEN needs `contents: write` on the tap repository only.
+
+set -euo pipefail
+
+: "${VERSION:?set VERSION, e.g. 0.2.0}"
+: "${TAG:?set TAG, e.g. v0.2.0}"
+: "${GH_TOKEN:?set GH_TOKEN with write access to the tap}"
+
+REPO="${REPO:-kryptonhq/loupe}"
+TAP_REPO="${TAP_REPO:-kryptonhq/homebrew-tap}"
+TEMPLATE="$(dirname "$0")/../packaging/homebrew/loupe.rb.template"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Tauri names macOS bundles "<product>_<version>_<arch>.dmg".
+arm_dmg="Loupe_${VERSION}_aarch64.dmg"
+intel_dmg="Loupe_${VERSION}_x64.dmg"
+
+echo "downloading release assets for $TAG"
+gh release download "$TAG" --repo "$REPO" --dir "$work" \
+  --pattern "$arm_dmg" --pattern "$intel_dmg"
+
+sha_arm="$(shasum -a 256 "$work/$arm_dmg" | cut -d' ' -f1)"
+sha_intel="$(shasum -a 256 "$work/$intel_dmg" | cut -d' ' -f1)"
+
+echo "  $arm_dmg   $sha_arm"
+echo "  $intel_dmg $sha_intel"
+
+sed \
+  -e "s|__VERSION__|${VERSION}|g" \
+  -e "s|__SHA256_ARM__|${sha_arm}|g" \
+  -e "s|__SHA256_INTEL__|${sha_intel}|g" \
+  "$TEMPLATE" > "$work/loupe.rb"
+
+# Fail loudly rather than pushing a cask with an unsubstituted
+# placeholder, which Homebrew would accept and then fail to install.
+if grep -q "__" "$work/loupe.rb"; then
+  echo "error: unsubstituted placeholder in the rendered cask" >&2
+  grep -n "__" "$work/loupe.rb" >&2
+  exit 1
+fi
+
+echo "cloning $TAP_REPO"
+git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/${TAP_REPO}.git" "$work/tap"
+
+mkdir -p "$work/tap/Casks"
+cp "$work/loupe.rb" "$work/tap/Casks/loupe.rb"
+
+cd "$work/tap"
+if git diff --quiet; then
+  echo "cask already up to date at $VERSION"
+  exit 0
+fi
+
+git config user.name "loupe-release"
+git config user.email "noreply@krypton.ai"
+git add Casks/loupe.rb
+git commit -m "loupe ${VERSION}"
+git push
+
+echo "tap updated to $VERSION"

--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -60,15 +60,24 @@ mkdir -p "$work/tap/Casks"
 cp "$work/loupe.rb" "$work/tap/Casks/loupe.rb"
 
 cd "$work/tap"
-if git diff --quiet; then
+git config user.name "loupe-release"
+git config user.email "noreply@krypton.ai"
+
+# Staged before the comparison: on the first release the cask does not
+# exist yet, and `git diff` does not see untracked files — it would
+# report the tree clean and skip the push that matters most.
+git add Casks/loupe.rb
+if git diff --cached --quiet; then
   echo "cask already up to date at $VERSION"
   exit 0
 fi
 
-git config user.name "loupe-release"
-git config user.email "noreply@krypton.ai"
-git add Casks/loupe.rb
 git commit -m "loupe ${VERSION}"
-git push
 
-echo "tap updated to $VERSION"
+# An empty tap has no branch yet, and a clone of one leaves HEAD unborn.
+# Pushing an explicit refspec works in both cases, and does not assume
+# the tap's default branch is called main.
+branch="$(git symbolic-ref --short HEAD 2>/dev/null || echo main)"
+git push origin "HEAD:refs/heads/${branch}"
+
+echo "tap updated to $VERSION on ${branch}"

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Keep the version in step across the three files that carry it.
+
+`package.json`, `src-tauri/Cargo.toml` and `src-tauri/tauri.conf.json` each
+hold their own copy, and only the last one decides what the installer is
+called. A release built from mismatched manifests produces a DMG whose
+name disagrees with its tag, which is the sort of thing nobody notices
+until a Homebrew cask 404s.
+
+    scripts/version.py                 # print the current version
+    scripts/version.py --set 0.2.0     # rewrite all three
+    scripts/version.py --check v0.2.0  # assert they match a git tag
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+PACKAGE_JSON = ROOT / "package.json"
+CARGO_TOML = ROOT / "src-tauri" / "Cargo.toml"
+TAURI_CONF = ROOT / "src-tauri" / "tauri.conf.json"
+
+# A release version, no pre-release suffix: Cargo, npm and Tauri each
+# accept slightly different shapes, and the intersection is plain semver.
+SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def read_json(path: pathlib.Path) -> str:
+    return json.loads(path.read_text())["version"]
+
+
+def read_cargo() -> str:
+    # Only the first `version =` — the dependency table has its own, and
+    # a regex that matches those would rewrite the wrong line.
+    for line in CARGO_TOML.read_text().splitlines():
+        match = re.match(r'^version\s*=\s*"([^"]+)"', line)
+        if match:
+            return match.group(1)
+    raise SystemExit(f"no version in {CARGO_TOML}")
+
+
+def current() -> dict[str, str]:
+    return {
+        str(PACKAGE_JSON.relative_to(ROOT)): read_json(PACKAGE_JSON),
+        str(CARGO_TOML.relative_to(ROOT)): read_cargo(),
+        str(TAURI_CONF.relative_to(ROOT)): read_json(TAURI_CONF),
+    }
+
+
+def set_version(version: str) -> None:
+    if not SEMVER.match(version):
+        raise SystemExit(f"not a release version: {version} (expected X.Y.Z)")
+
+    for path in (PACKAGE_JSON, TAURI_CONF):
+        data = json.loads(path.read_text())
+        data["version"] = version
+        # Two spaces and a trailing newline, which is what both files
+        # already use — a formatting-only diff hides the real change.
+        path.write_text(json.dumps(data, indent=2) + "\n")
+
+    lines = CARGO_TOML.read_text().splitlines(keepends=True)
+    for i, line in enumerate(lines):
+        if re.match(r'^version\s*=\s*"', line):
+            lines[i] = f'version = "{version}"\n'
+            break
+    CARGO_TOML.write_text("".join(lines))
+
+    print(f"set {version} in {len(current())} files")
+
+
+def check(tag: str) -> None:
+    """Assert every manifest matches the tag, which is what CI runs."""
+    expected = tag[1:] if tag.startswith("v") else tag
+    found = current()
+
+    mismatched = {p: v for p, v in found.items() if v != expected}
+    if mismatched:
+        print(f"tag {tag} expects version {expected}, but:")
+        for path, version in sorted(mismatched.items()):
+            print(f"  {path}: {version}")
+        print("\nrun: scripts/version.py --set " + expected)
+        raise SystemExit(1)
+
+    print(f"all manifests agree on {expected}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--set", metavar="X.Y.Z", help="rewrite every manifest")
+    group.add_argument("--check", metavar="TAG", help="assert they match a tag")
+    args = parser.parse_args()
+
+    if args.set:
+        set_version(args.set)
+    elif args.check:
+        check(args.check)
+    else:
+        versions = set(current().values())
+        if len(versions) != 1:
+            for path, version in sorted(current().items()):
+                print(f"{path}: {version}", file=sys.stderr)
+            raise SystemExit("manifests disagree")
+        print(versions.pop())
+
+
+if __name__ == "__main__":
+    main()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,6 +39,9 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "macOS": {
+      "minimumSystemVersion": "10.15"
+    }
   }
 }


### PR DESCRIPTION
Tag-driven releases for all three platforms, published as GitHub
releases, plus a Homebrew cask.

```bash
scripts/version.py --set 0.2.0
git commit -sam "release: 0.2.0" && git tag v0.2.0 && git push --follow-tags
```

Every platform builds into one draft release, which is published only
once all of them have landed — so a release is never half-visible while
Windows is still compiling. A failed run can be retried from the Actions
tab without moving the tag.

## Artifacts

| Platform | Artifacts |
| --- | --- |
| macOS (Apple Silicon) | `Loupe_<version>_aarch64.dmg` |
| macOS (Intel) | `Loupe_<version>_x64.dmg` |
| Linux | `.AppImage`, `.deb`, `.rpm` |
| Windows | `.msi`, `-setup.exe` |

Two macOS DMGs rather than a universal binary, so each download is the
size of one architecture; Homebrew picks the right one from the cask's
`arch` stanza. Linux builds on `ubuntu-22.04` rather than the newest
runner — the binary picks up the glibc it was built against, and 24.04
would refuse to start on anything older.

## Version drift

Three files carry the version and drift silently. The installer is named
from the manifest rather than the tag, so a mismatch puts a
`Loupe_0.1.0_aarch64.dmg` inside a `v0.2.0` release and 404s the cask.
`scripts/version.py` sets all three, the release refuses a tag they
disagree with, and CI checks them on every PR so it never gets that far.

## Homebrew

The cask goes to a tap this project owns —
`github.com/kryptonhq/homebrew-tap` — rather than to `homebrew/cask`.
A tap can be created today and needs nobody's approval, while
homebrew/cask judges submissions on
[notability](https://docs.brew.sh/Acceptable-Casks). Moving later is a
submission, not a migration.

Checksums come from the published artifacts rather than a local build,
so what the cask claims is what people actually download. The job skips
with a notice until `HOMEBREW_TAP_TOKEN` exists, so releases work before
the tap does.

## Verified

I built the macOS bundle rather than assuming Tauri's naming, since the
cask's `url` and `app` stanzas depend on it:

- artifact is `Loupe_0.1.0_aarch64.dmg`
- the DMG contains `Loupe.app` and the `/Applications` symlink
- bundle identifier is `ai.krypton.loupe`, which is what the `zap`
  paths remove

That build also surfaced a real bug: the bundle advertised
`LSMinimumSystemVersion 10.13`, a version Tauri v2 cannot run on. Now
set to `10.15` — Tauri's own floor — and the cask's `depends_on` matches
it. Confirmed by rebuilding.

The local build is ad-hoc signed with no team identifier, which is
exactly the unsigned case described below.

## What this does not do

**Signing is wired but not enabled.** With the Apple secrets present
Tauri signs and notarises; without them it builds unsigned. Unsigned is
not a cosmetic problem — Gatekeeper refuses to open the app at all, and
Homebrew
[will not accept a cask that needs Gatekeeper bypassed](https://docs.brew.sh/Acceptable-Casks).
So the `brew` path realistically needs an Apple Developer account
(99 USD/year) before it is worth promoting. `RELEASING.md` lists the six
secrets.

Windows installers work unsigned but trip SmartScreen. That needs a
code-signing certificate; there is no credential-only path.

Auto-update is not set up — Tauri ships an updater, but it needs a key
pair and a manifest, and it is worth doing deliberately rather than
folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)