### PR TITLE
Fix macOS builds: do not define the Apple certificate variables when there is none

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,24 +152,53 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # An unset secret is still a *defined* environment variable — it is
+      # the empty string, not absent — and Tauri reads a defined
+      # APPLE_CERTIFICATE as "there is a certificate to import". It then
+      # runs `security import` on nothing and the build dies with
+      # "failed to import keychain certificate".
+      #
+      # So the certificate variables are only allowed to exist when
+      # there is a certificate, which needs two build steps rather than
+      # one conditional expression.
+      - id: signing
+        run: |
+          if [ -n "${{ secrets.APPLE_CERTIFICATE }}" ]; then
+            echo "mode=certificate" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=adhoc" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
+      # The usual path today: no certificate anywhere.
+      #
+      # The explicit "-" matters more than it looks. Left entirely alone
+      # Tauri does not codesign the bundle at all, and the only signature
+      # is the linker's — which macOS reads as *malformed* and reports as
+      # "Loupe is damaged and can't be opened", pointing the user at a
+      # corrupt download rather than at an unsigned app. Ad-hoc signing
+      # produces a valid signature with the hardened runtime, so the app
+      # is refused for the reason it actually is: not notarised.
+      #
+      # Ignored on Linux and Windows, which have no such concept.
       - uses: tauri-apps/tauri-action@v0
+        if: steps.signing.outputs.mode == 'adhoc'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # macOS signing and notarisation. The six secrets go together;
-          # with all of them Tauri signs with the real identity and
-          # notarises, and with none of them it falls back to "-".
-          #
-          # That fallback matters more than it looks. Left to itself
-          # Tauri does not codesign the bundle at all, and the only
-          # signature is the linker's — which macOS reads as *malformed*
-          # and reports as "Loupe is damaged and can't be opened",
-          # pointing the user at a corrupt download rather than at an
-          # unsigned app. An explicit ad-hoc identity produces a valid
-          # signature with the hardened runtime, so the app is refused
-          # for the reason it actually is: not notarised.
+          APPLE_SIGNING_IDENTITY: "-"
+        with:
+          releaseId: ${{ needs.draft.outputs.release_id }}
+          args: ${{ matrix.args }}
+
+      # Signed and notarised. The six secrets go together — a partial set
+      # makes Tauri attempt a notarisation it cannot finish.
+      - uses: tauri-apps/tauri-action@v0
+        if: steps.signing.outputs.mode == 'certificate'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -93,8 +93,14 @@ base64 -i DeveloperID.p12 | pbcopy
 ```
 
 When they are all present Tauri signs with the real identity and
-notarises. When `APPLE_SIGNING_IDENTITY` is absent the workflow passes
-`-` instead, which is the ad-hoc case above.
+notarises; otherwise it ad-hoc signs.
+
+The workflow chooses between those with two separate build steps rather
+than one step and a fallback value. An unset secret is still a *defined*
+environment variable — the empty string, not absent — and Tauri reads a
+defined `APPLE_CERTIFICATE` as "there is a certificate to import", then
+fails on `security import` with nothing to import. The certificate
+variables therefore only exist when there is a certificate.
 
 ### Windows
 


### PR DESCRIPTION
Both macOS builds failed on the first release run
([30716012182](https://github.com/kryptonhq/loupe/actions/runs/30716012182)):

```
failed to bundle project: failed codesign application:
failed to run command security import: failed to import keychain certificate
```

## Cause

An unset GitHub secret referenced in `env:` is still a **defined**
environment variable — the empty string, not absent. Tauri reads a
defined `APPLE_CERTIFICATE` as "there is a certificate to import", ran
`security import` on nothing, and the bundle step died.

The ad-hoc fallback was the right idea; expressing it as
`${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}` on a single step was not,
because that leaves `APPLE_CERTIFICATE` and its password defined
alongside it.

## Fix

Two build steps, chosen by whether the secret has content, so the
certificate variables only exist when a certificate does. Ad-hoc is the
path taken today; adding the six secrets later switches to the signed
and notarised one with no further change.

Linux and Windows are unaffected either way — they ignore the signing
identity. Linux had already succeeded on the failed run and uploaded
`Loupe_0.1.0_amd64.AppImage`, `Loupe_0.1.0_amd64.deb` and
`Loupe-0.1.0-1.x86_64.rpm`, which confirms the publish gate's patterns
for that platform.

## After merging

The `v0.1.0` tag moves to the fixed commit and the release is re-run.
Nothing was published — the release is still a draft, so no version was
ever visible with missing platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)