### PR TITLE
Test coverage, and a security pass over the repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,87 @@
+version: 2
+
+# Loupe's dependency surface is large and mostly transitive: Tauri pulls
+# in a webview stack, kube pulls in a TLS stack. Neither is something a
+# human will notice going stale, and the advisories that matter arrive
+# long after the code stops changing — so the updates are scheduled
+# rather than left to whoever next opens the repository.
+#
+# Grouped deliberately. One PR per crate would be a wall of noise nobody
+# reviews, and a wall nobody reviews is worse than no automation: it
+# trains people to merge dependency bumps without reading them. Security
+# updates are kept ungrouped so they arrive on their own and get looked
+# at.
+
+updates:
+  - package-ecosystem: cargo
+    directory: /src-tauri
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    # A release published an hour ago is the one most likely to have been
+    # published by someone who just took over the account. Waiting a few
+    # days costs nothing here and is the window in which a compromised
+    # package usually gets yanked. Security updates ignore the delay.
+    cooldown:
+      default-days: 7
+    groups:
+      # Tauri's crates move together and only work together; splitting
+      # them produces PRs that cannot build on their own.
+      tauri:
+        patterns:
+          - "tauri*"
+          - "wry"
+          - "window-vibrancy"
+      kubernetes:
+        patterns:
+          - "kube*"
+          - "k8s-openapi"
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react*"
+      # The test and build toolchain. Every advisory this repository has
+      # had so far came from here, and none of it ships in the app.
+      tooling:
+        patterns:
+          - "vite*"
+          - "@vitejs/*"
+          - "@vitest/*"
+          - "vitest"
+          - "typescript"
+          - "postcss"
+          - "autoprefixer"
+          - "tailwindcss"
+          - "@testing-library/*"
+          - "jsdom"
+
+  # Actions are executable code running with a token, and the workflows
+  # pin them to commit SHAs so a moved tag cannot swap one out from under
+  # us. A pin nobody updates is its own problem, which is what this is
+  # for: Dependabot reads the `# v4` trailing comment and bumps both.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # Need the PR's commits, not just the merge commit.
           fetch-depth: 0
@@ -68,18 +68,19 @@ jobs:
     name: Version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - run: python3 scripts/version.py
 
   rust:
     name: Rust
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
+          toolchain: stable
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src-tauri
 
@@ -96,7 +97,9 @@ jobs:
       - name: Clippy
         run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
 
-      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2
+        with:
+          tool: cargo-llvm-cov
 
       # The cluster-backed tests are #[ignore]d and stay that way here:
       # CI has no cluster, and a test that silently needs one is worse
@@ -111,7 +114,7 @@ jobs:
             --lcov --output-path lcov.info
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
@@ -124,11 +127,11 @@ jobs:
     name: Frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -139,7 +142,7 @@ jobs:
       - run: pnpm build
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/lcov.info

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,59 @@
+name: codeql
+
+# GitHub's own analysis, free on public repositories.
+#
+# It overlaps with Semgrep and is kept anyway: Semgrep matches patterns,
+# CodeQL follows data. The question that matters most for Loupe — can a
+# string that came from a cluster reach somewhere it gets executed — is a
+# dataflow question, and pattern matching answers it only by accident.
+#
+# Results land in the repository's Security tab and are annotated on the
+# pull request, rather than being buried in a job log.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Offset from `security.yml` so a bad morning is not simultaneously
+    # every check going red.
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    permissions:
+      # Writing the results back to the Security tab.
+      security-events: write
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: rust
+            build-mode: none
+
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Initialize
+        uses: github/codeql-action/init@a2983b8bed1923f44751c5c43237f479442827b3 # v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # `security-extended` over the default: this is a desktop app
+          # holding cluster credentials, and the extra queries are worth
+          # more here than the noise they cost.
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@a2983b8bed1923f44751c5c43237f479442827b3 # v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,16 +39,25 @@ jobs:
       tag: ${{ steps.resolve.outputs.tag }}
       version: ${{ steps.resolve.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.tag || github.ref }}
 
+      # The tag reaches the shell through the environment, never through
+      # `${{ }}`. Interpolation happens before the shell sees the script,
+      # so a tag containing a quote and a semicolon would not be a
+      # mis-parsed string — it would be a second command, running in the
+      # job that holds the release and tap tokens. `workflow_dispatch`
+      # narrows who can supply one to people with write access, which is
+      # a smaller set than the internet and a larger one than the people
+      # trusted with those secrets.
       - id: resolve
+        env:
+          RAW_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          tag="${{ inputs.tag || github.ref_name }}"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
-          python3 scripts/version.py --check "$tag"
+          echo "tag=$RAW_TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${RAW_TAG#v}" >> "$GITHUB_OUTPUT"
+          python3 scripts/version.py --check "$RAW_TAG"
 
   # One draft up front, so the matrix uploads into it rather than racing
   # to create it.
@@ -59,15 +68,20 @@ jobs:
     outputs:
       release_id: ${{ steps.create.outputs.result }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.version.outputs.tag }}
 
       - id: create
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          # Same reasoning as the resolve step: this value originates in
+          # `inputs.tag`, and interpolating it into the script body would
+          # let it close the string and run as JavaScript.
+          TAG: ${{ needs.version.outputs.tag }}
         with:
           script: |
-            const tag = "${{ needs.version.outputs.tag }}";
+            const tag = process.env.TAG;
             const { owner, repo } = context.repo;
 
             // Reuse the draft if this is a retry, rather than stacking
@@ -120,25 +134,26 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.version.outputs.tag }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
+          toolchain: stable
           # Empty for the native builds; the macOS jobs cross-compile,
           # and the Intel one is a cross-compile on an Arm runner.
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src-tauri
           key: ${{ matrix.target }}
@@ -161,9 +176,16 @@ jobs:
       # So the certificate variables are only allowed to exist when
       # there is a certificate, which needs two build steps rather than
       # one conditional expression.
+      #
+      # Read through the environment rather than interpolated into the
+      # script: `${{ }}` pastes the certificate itself into the shell
+      # source, where a stray quote would break the script and the value
+      # is one `set -x` away from the log.
       - id: signing
+        env:
+          CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
         run: |
-          if [ -n "${{ secrets.APPLE_CERTIFICATE }}" ]; then
+          if [ -n "$CERTIFICATE" ]; then
             echo "mode=certificate" >> "$GITHUB_OUTPUT"
           else
             echo "mode=adhoc" >> "$GITHUB_OUTPUT"
@@ -181,7 +203,7 @@ jobs:
       # is refused for the reason it actually is: not notarised.
       #
       # Ignored on Linux and Windows, which have no such concept.
-      - uses: tauri-apps/tauri-action@v0
+      - uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
         if: steps.signing.outputs.mode == 'adhoc'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -192,7 +214,7 @@ jobs:
 
       # Signed and notarised. The six secrets go together — a partial set
       # makes Tauri attempt a notarisation it cannot finish.
-      - uses: tauri-apps/tauri-action@v0
+      - uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
         if: steps.signing.outputs.mode == 'certificate'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -211,11 +233,13 @@ jobs:
     needs: [version, draft, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          RELEASE_ID: ${{ needs.draft.outputs.release_id }}
         with:
           script: |
             const { owner, repo } = context.repo;
-            const release_id = Number("${{ needs.draft.outputs.release_id }}");
+            const release_id = Number(process.env.RELEASE_ID);
 
             const assets = await github.rest.repos.listReleaseAssets({ owner, repo, release_id });
             const names = assets.data.map((a) => a.name);
@@ -255,7 +279,7 @@ jobs:
       VERSION: ${{ needs.version.outputs.version }}
       TAG: ${{ needs.version.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.version.outputs.tag }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,105 @@
+name: security
+
+# Kept out of `ci.yml` on purpose.
+#
+# These checks fail for reasons that have nothing to do with the change
+# under review: an advisory published overnight turns every open PR red.
+# That is worth knowing and is not worth blocking a docs fix on, so this
+# is a separate status. Require `ci` in branch protection; read this one.
+#
+# The weekly run is the point of the whole file. Dependency risk arrives
+# on the advisory database's schedule, not on ours, and a repository that
+# only scans when someone pushes stops being scanned the moment it
+# stabilises.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Monday morning UTC, before the Dependabot PRs land.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "22"
+  PNPM_VERSION: "10"
+
+jobs:
+  # Known vulnerabilities in what we actually depend on.
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: src-tauri
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2
+        with:
+          tool: cargo-audit
+
+      # Plain `cargo audit`, not `--deny warnings`.
+      #
+      # The Rust tree carries ~17 "unmaintained" warnings, essentially
+      # all of them gtk-rs GTK3 bindings reached through Tauri's Linux
+      # backend. None are vulnerabilities and none are ours to fix —
+      # they resolve when Tauri moves off GTK3. Failing on them would
+      # mean a permanently red job, which is the same as no job at all.
+      # Vulnerabilities still exit non-zero.
+      - name: Rust advisories
+        run: cargo audit --file src-tauri/Cargo.lock
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      # Note this covers the build and test toolchain as well as what
+      # ships. A vulnerable vitest cannot reach a user, but it can reach
+      # a maintainer's machine and this repository's release token.
+      - name: npm advisories
+        run: pnpm audit --audit-level moderate
+
+  # Static analysis for the patterns an advisory database cannot see:
+  # our own code.
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      # Rulesets are named explicitly rather than using `--config auto`,
+      # which requires an account and reports findings to a service. This
+      # form runs entirely in the job; nothing about the code leaves it.
+      - name: Scan
+        run: |
+          semgrep scan \
+            --config p/default \
+            --config p/rust \
+            --config p/typescript \
+            --config p/react \
+            --config p/secrets \
+            --config p/command-injection \
+            --metrics off \
+            --error \
+            --exclude node_modules \
+            --exclude dist \
+            --exclude src-tauri/target

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@tanstack/react-query": "^5.101.4",
     "@tauri-apps/api": "^2",
-    "@tauri-apps/plugin-opener": "^2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
@@ -27,13 +26,13 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
-    "@vitest/coverage-v8": "2.1.9",
-    "autoprefixer": "10.5.0",
+    "@vitest/coverage-v8": "3.2.7",
+    "autoprefixer": "10.5.4",
     "jsdom": "^30.0.1",
-    "postcss": "8.5.15",
+    "postcss": "8.5.25",
     "tailwindcss": "3.4.19",
     "typescript": "~5.8.3",
     "vite": "^7.0.4",
-    "vitest": "^2.1.9"
+    "vitest": "^3.2.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.11.1
-      '@tauri-apps/plugin-opener':
-        specifier: ^2
-        version: 2.5.4
       react:
         specifier: ^19.1.0
         version: 19.2.8
@@ -46,17 +43,17 @@ importers:
         specifier: ^4.6.0
         version: 4.7.0(vite@7.3.6(jiti@1.21.7))
       '@vitest/coverage-v8':
-        specifier: 2.1.9
-        version: 2.1.9(vitest@2.1.9(jsdom@30.0.1))
+        specifier: 3.2.7
+        version: 3.2.7(vitest@3.2.7(jiti@1.21.7)(jsdom@30.0.1))
       autoprefixer:
-        specifier: 10.5.0
-        version: 10.5.0(postcss@8.5.15)
+        specifier: 10.5.4
+        version: 10.5.4(postcss@8.5.25)
       jsdom:
         specifier: ^30.0.1
         version: 30.0.1
       postcss:
-        specifier: 8.5.15
-        version: 8.5.15
+        specifier: 8.5.25
+        version: 8.5.25
       tailwindcss:
         specifier: 3.4.19
         version: 3.4.19
@@ -67,8 +64,8 @@ importers:
         specifier: ^7.0.4
         version: 7.3.6(jiti@1.21.7)
       vitest:
-        specifier: ^2.1.9
-        version: 2.1.9(jsdom@30.0.1)
+        specifier: ^3.2.7
+        version: 3.2.7(jiti@1.21.7)(jsdom@30.0.1)
 
 packages:
 
@@ -178,8 +175,9 @@ packages:
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@bcoe/v8-coverage@0.2.3':
-    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -221,34 +219,16 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@esbuild/aix-ppc64@0.21.5':
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.28.1':
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.1':
@@ -257,34 +237,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.28.1':
     resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.1':
@@ -293,22 +255,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -317,22 +267,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.1':
@@ -341,22 +279,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.1':
@@ -365,22 +291,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -389,34 +303,16 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.28.1':
     resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.28.1':
@@ -431,12 +327,6 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.28.1':
     resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
@@ -447,12 +337,6 @@ packages:
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -467,23 +351,11 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-
-  '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-arm64@0.28.1':
     resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
@@ -491,22 +363,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.1':
@@ -780,9 +640,6 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@tauri-apps/plugin-opener@2.5.4':
-    resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
-
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -829,6 +686,12 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -846,43 +709,43 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vitest/coverage-v8@2.1.9':
-    resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
+  '@vitest/coverage-v8@3.2.7':
+    resolution: {integrity: sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==}
     peerDependencies:
-      '@vitest/browser': 2.1.9
-      vitest: 2.1.9
+      '@vitest/browser': 3.2.7
+      vitest: 3.2.7
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@2.1.9':
-    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
 
-  '@vitest/mocker@2.1.9':
-    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@2.1.9':
-    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
 
-  '@vitest/runner@2.1.9':
-    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
 
-  '@vitest/snapshot@2.1.9':
-    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
 
-  '@vitest/spy@2.1.9':
-    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
 
-  '@vitest/utils@2.1.9':
-    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -925,8 +788,11 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  autoprefixer@10.5.0:
-    resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+
+  autoprefixer@10.5.4:
+    resolution: {integrity: sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
@@ -1082,11 +948,6 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
-  esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
-    engines: {node: '>=12'}
-    hasBin: true
-
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
@@ -1227,8 +1088,14 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   jsdom@30.0.1:
     resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
@@ -1354,8 +1221,8 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
@@ -1423,8 +1290,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-format@27.5.1:
@@ -1547,6 +1414,9 @@ packages:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -1593,12 +1463,12 @@ packages:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
-  tinyrainbow@1.2.0:
-    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
 
-  tinyspy@3.0.2:
-    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@7.4.10:
@@ -1641,41 +1511,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  vite-node@2.1.9:
-    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
-
-  vite@5.4.21:
-    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
 
   vite@7.3.6:
     resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
@@ -1717,19 +1556,22 @@ packages:
       yaml:
         optional: true
 
-  vitest@2.1.9:
-    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.9
-      '@vitest/ui': 2.1.9
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
         optional: true
       '@types/node':
         optional: true
@@ -1930,7 +1772,7 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@bcoe/v8-coverage@0.2.3': {}
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -1960,103 +1802,52 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@esbuild/aix-ppc64@0.21.5':
-    optional: true
-
   '@esbuild/aix-ppc64@0.28.1':
-    optional: true
-
-  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.21.5':
-    optional: true
-
   '@esbuild/android-arm@0.28.1':
-    optional: true
-
-  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.21.5':
-    optional: true
-
   '@esbuild/darwin-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.21.5':
-    optional: true
-
   '@esbuild/linux-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.21.5':
-    optional: true
-
   '@esbuild/linux-ia32@0.28.1':
-    optional: true
-
-  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.21.5':
-    optional: true
-
   '@esbuild/linux-mips64el@0.28.1':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.21.5':
-    optional: true
-
   '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.21.5':
-    optional: true
-
   '@esbuild/linux-s390x@0.28.1':
-    optional: true
-
-  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.28.1':
@@ -2065,16 +1856,10 @@ snapshots:
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.21.5':
-    optional: true
-
   '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -2083,25 +1868,13 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.21.5':
-    optional: true
-
   '@esbuild/sunos-x64@0.28.1':
-    optional: true
-
-  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.21.5':
-    optional: true
-
   '@esbuild/win32-ia32@0.28.1':
-    optional: true
-
-  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -2290,10 +2063,6 @@ snapshots:
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
 
-  '@tauri-apps/plugin-opener@2.5.4':
-    dependencies:
-      '@tauri-apps/api': 2.11.1
-
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -2352,6 +2121,13 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.8
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/react-dom@19.2.4(@types/react@19.2.18)':
@@ -2374,10 +2150,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(jsdom@30.0.1))':
+  '@vitest/coverage-v8@3.2.7(vitest@3.2.7(jiti@1.21.7)(jsdom@30.0.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 0.2.3
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
       debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -2387,50 +2164,52 @@ snapshots:
       magicast: 0.3.5
       std-env: 3.10.0
       test-exclude: 7.0.2
-      tinyrainbow: 1.2.0
-      vitest: 2.1.9(jsdom@30.0.1)
+      tinyrainbow: 2.0.0
+      vitest: 3.2.7(jiti@1.21.7)(jsdom@30.0.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@2.1.9':
+  '@vitest/expect@3.2.7':
     dependencies:
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
       chai: 5.3.3
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.21)':
+  '@vitest/mocker@3.2.7(vite@7.3.6(jiti@1.21.7))':
     dependencies:
-      '@vitest/spy': 2.1.9
+      '@vitest/spy': 3.2.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21
+      vite: 7.3.6(jiti@1.21.7)
 
-  '@vitest/pretty-format@2.1.9':
+  '@vitest/pretty-format@3.2.7':
     dependencies:
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
-  '@vitest/runner@2.1.9':
+  '@vitest/runner@3.2.7':
     dependencies:
-      '@vitest/utils': 2.1.9
-      pathe: 1.1.2
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
 
-  '@vitest/snapshot@2.1.9':
+  '@vitest/snapshot@3.2.7':
     dependencies:
-      '@vitest/pretty-format': 2.1.9
+      '@vitest/pretty-format': 3.2.7
       magic-string: 0.30.21
-      pathe: 1.1.2
+      pathe: 2.0.3
 
-  '@vitest/spy@2.1.9':
+  '@vitest/spy@3.2.7':
     dependencies:
-      tinyspy: 3.0.2
+      tinyspy: 4.0.4
 
-  '@vitest/utils@2.1.9':
+  '@vitest/utils@3.2.7':
     dependencies:
-      '@vitest/pretty-format': 2.1.9
+      '@vitest/pretty-format': 3.2.7
       loupe: 3.2.1
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
   ansi-regex@5.0.1: {}
 
@@ -2461,13 +2240,19 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  autoprefixer@10.5.0(postcss@8.5.15):
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
+  autoprefixer@10.5.4(postcss@8.5.25):
     dependencies:
       browserslist: 4.28.7
       caniuse-lite: 1.0.30001806
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.15
+      postcss: 8.5.25
       postcss-value-parser: 4.2.0
 
   balanced-match@1.0.2: {}
@@ -2595,32 +2380,6 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
-
-  esbuild@0.21.5:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -2777,7 +2536,11 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   jsdom@30.0.1:
     dependencies:
@@ -2893,7 +2656,7 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
-  pathe@1.1.2: {}
+  pathe@2.0.3: {}
 
   pathval@2.0.1: {}
 
@@ -2907,28 +2670,28 @@ snapshots:
 
   pirates@4.0.7: {}
 
-  postcss-import@15.1.0(postcss@8.5.15):
+  postcss-import@15.1.0(postcss@8.5.25):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.25
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-js@4.1.0(postcss@8.5.15):
+  postcss-js@4.1.0(postcss@8.5.25):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.15
+      postcss: 8.5.25
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.25):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.15
+      postcss: 8.5.25
 
-  postcss-nested@6.2.0(postcss@8.5.15):
+  postcss-nested@6.2.0(postcss@8.5.25):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.25
       postcss-selector-parser: 6.1.4
 
   postcss-selector-parser@6.1.4:
@@ -2938,7 +2701,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.15:
+  postcss@8.5.25:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -3075,6 +2838,10 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   sucrase@3.35.1:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -3109,11 +2876,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.15
-      postcss-import: 15.1.0(postcss@8.5.15)
-      postcss-js: 4.1.0(postcss@8.5.15)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)
-      postcss-nested: 6.2.0(postcss@8.5.15)
+      postcss: 8.5.25
+      postcss-import: 15.1.0(postcss@8.5.25)
+      postcss-js: 4.1.0(postcss@8.5.25)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.25)
+      postcss-nested: 6.2.0(postcss@8.5.25)
       postcss-selector-parser: 6.1.4
       resolve: 1.22.12
       sucrase: 3.35.1
@@ -3146,9 +2913,9 @@ snapshots:
 
   tinypool@1.1.1: {}
 
-  tinyrainbow@1.2.0: {}
+  tinyrainbow@2.0.0: {}
 
-  tinyspy@3.0.2: {}
+  tinyspy@4.0.4: {}
 
   tldts-core@7.4.10: {}
 
@@ -3182,15 +2949,16 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@2.1.9:
+  vite-node@3.2.4(jiti@1.21.7):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
-      pathe: 1.1.2
-      vite: 5.4.21
+      pathe: 2.0.3
+      vite: 7.3.6(jiti@1.21.7)
     transitivePeerDependencies:
       - '@types/node'
+      - jiti
       - less
       - lightningcss
       - sass
@@ -3199,52 +2967,50 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-
-  vite@5.4.21:
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.15
-      rollup: 4.62.4
-    optionalDependencies:
-      fsevents: 2.3.3
+      - tsx
+      - yaml
 
   vite@7.3.6(jiti@1.21.7):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.15
+      postcss: 8.5.25
       rollup: 4.62.4
       tinyglobby: 0.2.17
     optionalDependencies:
       fsevents: 2.3.3
       jiti: 1.21.7
 
-  vitest@2.1.9(jsdom@30.0.1):
+  vitest@3.2.7(jiti@1.21.7)(jsdom@30.0.1):
     dependencies:
-      '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21)
-      '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.9
-      '@vitest/snapshot': 2.1.9
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.6(jiti@1.21.7))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.4.0
       magic-string: 0.30.21
-      pathe: 1.1.2
+      pathe: 2.0.3
+      picomatch: 4.0.5
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
+      tinyglobby: 0.2.17
       tinypool: 1.1.1
-      tinyrainbow: 1.2.0
-      vite: 5.4.21
-      vite-node: 2.1.9
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(jiti@1.21.7)
+      vite-node: 3.2.4(jiti@1.21.7)
       why-is-node-running: 2.3.0
     optionalDependencies:
       jsdom: 30.0.1
     transitivePeerDependencies:
+      - jiti
       - less
       - lightningcss
       - msw
@@ -3254,6 +3020,8 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -102,108 +102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,23 +121,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
-name = "async-trait"
-version = "0.1.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
 ]
 
 [[package]]
@@ -346,19 +227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -548,15 +416,6 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -997,12 +856,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endi"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
-
-[[package]]
 name = "enum-ordinalize"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,27 +873,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
-]
-
-[[package]]
-name = "enumflags2"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
-dependencies = [
- "enumflags2_derive",
- "serde",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -1226,19 +1058,6 @@ name = "futures-io"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
-
-[[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
 
 [[package]]
 name = "futures-macro"
@@ -1631,12 +1450,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,25 +1768,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "is-docker"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "is-wsl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
-dependencies = [
- "is-docker",
- "once_cell",
-]
 
 [[package]]
 name = "itoa"
@@ -2373,12 +2167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,7 +2202,6 @@ dependencies = [
  "serde_yaml",
  "tauri",
  "tauri-build",
- "tauri-plugin-opener",
  "thiserror 2.0.19",
  "tokio",
  "window-vibrancy 0.8.0",
@@ -2770,17 +2557,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "open"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b3d059e795d52b8a72fef45658620edd4d9c359b338564aa14391ffa511ed5"
-dependencies = [
- "dunce",
- "is-wsl",
- "libc",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,16 +2575,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "ordered-stream"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
-dependencies = [
- "futures-core",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -3003,17 +2769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3056,20 +2811,6 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3336,19 +3077,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags 2.13.1",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4211,44 +3939,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tauri-plugin"
-version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
-dependencies = [
- "anyhow",
- "glob",
- "plist",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "tauri-utils",
- "walkdir",
-]
-
-[[package]]
-name = "tauri-plugin-opener"
-version = "2.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29"
-dependencies = [
- "dunce",
- "glob",
- "objc2-app-kit",
- "objc2-foundation",
- "open",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.19",
- "url",
- "windows",
- "zbus",
-]
-
-[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4346,19 +4036,6 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.4+spec-1.1.0",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.3",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4764,17 +4441,6 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
-name = "uds_windows"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
-dependencies = [
- "memoffset",
- "tempfile",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "unic-char-property"
@@ -5720,67 +5386,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zbus"
-version = "5.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
-dependencies = [
- "async-broadcast",
- "async-executor",
- "async-io",
- "async-lock",
- "async-process",
- "async-recursion",
- "async-task",
- "async-trait",
- "blocking",
- "enumflags2",
- "event-listener",
- "futures-core",
- "futures-lite",
- "hex",
- "libc",
- "ordered-stream",
- "rustix",
- "serde",
- "serde_repr",
- "tracing",
- "uds_windows",
- "uuid",
- "windows-sys 0.61.2",
- "winnow 1.0.4",
- "zbus_macros",
- "zbus_names",
- "zvariant",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "5.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
-dependencies = [
- "proc-macro-crate 3.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zbus_names"
-version = "4.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
-dependencies = [
- "serde",
- "winnow 1.0.4",
- "zvariant",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5865,43 +5470,3 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
-
-[[package]]
-name = "zvariant"
-version = "5.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "winnow 1.0.4",
- "zvariant_derive",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "5.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
-dependencies = [
- "proc-macro-crate 3.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.119",
- "winnow 1.0.4",
-]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,6 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = [] }
-tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # rustls-tls avoids linking OpenSSL. "ring" is not optional alongside it:

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,7 +5,6 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default",
     "core:window:allow-start-dragging",
     "core:window:allow-toggle-maximize"
   ]

--- a/src-tauri/src/cluster/data.rs
+++ b/src-tauri/src/cluster/data.rs
@@ -65,15 +65,11 @@ fn describe(key: String, raw: &[u8], reveal: bool) -> DataKey {
     }
 }
 
-pub async fn get_config_map_data(
-    session: &Session,
-    namespace: &str,
-    name: &str,
-) -> Result<ResourceData> {
-    let client = session.client().await?;
-    let api: Api<ConfigMap> = Api::namespaced(client, namespace);
-    let cm = api.get(name).await?;
-
+/// Describes a ConfigMap's contents.
+///
+/// Split from the fetch so the shape of what leaves the Rust side can be
+/// asserted without a cluster.
+fn config_map_data(cm: ConfigMap) -> ResourceData {
     let mut keys: Vec<DataKey> = cm
         .data
         .unwrap_or_default()
@@ -97,27 +93,32 @@ pub async fn get_config_map_data(
     );
 
     keys.sort_by(|a, b| a.key.cmp(&b.key));
-    Ok(ResourceData {
+    ResourceData {
         keys,
         type_: None,
         redacted: false,
-    })
+    }
+}
+
+pub async fn get_config_map_data(
+    session: &Session,
+    namespace: &str,
+    name: &str,
+) -> Result<ResourceData> {
+    let client = session.client().await?;
+    let api: Api<ConfigMap> = Api::namespaced(client, namespace);
+    Ok(config_map_data(api.get(name).await?))
 }
 
 /// A Secret's keys, with values withheld unless `reveal` names them.
 ///
 /// `reveal` is a list rather than a flag so the UI can show one value
 /// without putting every credential in the object on screen at once.
-pub async fn get_secret_data(
-    session: &Session,
-    namespace: &str,
-    name: &str,
-    reveal: Vec<String>,
-) -> Result<ResourceData> {
-    let client = session.client().await?;
-    let api: Api<Secret> = Api::namespaced(client, namespace);
-    let secret = api.get(name).await?;
-
+///
+/// Split from the fetch because this is the function that decides what
+/// leaves the process, and that decision deserves to be tested directly
+/// rather than only against whatever happens to be on a live cluster.
+fn secret_data(secret: Secret, reveal: &[String]) -> ResourceData {
     let mut keys: Vec<DataKey> = secret
         .data
         .unwrap_or_default()
@@ -129,14 +130,25 @@ pub async fn get_secret_data(
         .collect();
 
     keys.sort_by(|a, b| a.key.cmp(&b.key));
-    Ok(ResourceData {
+    ResourceData {
         keys,
         type_: secret.type_,
         // The tab always says values are held back, even when one has
         // been revealed — the state the user should assume is the
         // guarded one.
         redacted: true,
-    })
+    }
+}
+
+pub async fn get_secret_data(
+    session: &Session,
+    namespace: &str,
+    name: &str,
+    reveal: Vec<String>,
+) -> Result<ResourceData> {
+    let client = session.client().await?;
+    let api: Api<Secret> = Api::namespaced(client, namespace);
+    Ok(secret_data(api.get(name).await?, &reveal))
 }
 
 /// Replaces every value in an object's `data`/`stringData` maps.
@@ -236,6 +248,193 @@ mod tests {
         // Everything that is not a value is left alone.
         assert_eq!(object["type"], "Opaque");
         assert_eq!(object["metadata"]["name"], "db");
+    }
+
+    /// A Secret carrying the two keys a `kubernetes.io/basic-auth`
+    /// secret has, plus a binary one.
+    fn secret(entries: &[(&str, &[u8])], type_: Option<&str>) -> Secret {
+        Secret {
+            data: Some(
+                entries
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), k8s_openapi::ByteString(v.to_vec())))
+                    .collect(),
+            ),
+            type_: type_.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_secret_discloses_nothing_when_nothing_is_asked_for() {
+        // The default state of the Data tab. Opening a Secret must not
+        // put credentials on screen — a screen-share or a shoulder is
+        // enough to leak them, and the user only wanted the shape.
+        let data = secret_data(
+            secret(
+                &[("username", b"postgres"), ("password", b"hunter2")],
+                Some("Opaque"),
+            ),
+            &[],
+        );
+
+        assert!(data.redacted);
+        assert_eq!(key_names(&data), vec!["password", "username"]);
+        assert!(
+            data.keys.iter().all(|k| k.value.is_none()),
+            "no value may be returned without being named"
+        );
+        // Sizes still describe each key, which is what makes the
+        // withheld view useful rather than merely empty.
+        assert!(data.keys.iter().all(|k| k.bytes > 0));
+        assert_eq!(data.type_.as_deref(), Some("Opaque"));
+    }
+
+    #[test]
+    fn revealing_one_key_discloses_only_that_key() {
+        // The reason `reveal` is a list of names rather than a boolean:
+        // checking one credential must not put every other credential in
+        // the object on screen alongside it.
+        let data = secret_data(
+            secret(
+                &[
+                    ("username", b"postgres"),
+                    ("password", b"hunter2"),
+                    ("token", b"ey.J9"),
+                ],
+                Some("Opaque"),
+            ),
+            &["username".to_string()],
+        );
+
+        let by_key = |name: &str| data.keys.iter().find(|k| k.key == name).unwrap();
+        assert_eq!(by_key("username").value.as_deref(), Some("postgres"));
+        assert_eq!(by_key("password").value, None);
+        assert_eq!(by_key("token").value, None);
+        // Still flagged as redacted: the state to assume is the guarded
+        // one, even with one value on screen.
+        assert!(data.redacted);
+    }
+
+    #[test]
+    fn naming_a_key_that_does_not_exist_reveals_nothing_else() {
+        // A stale request from the UI — the key was renamed, or the
+        // Secret changed under it. It must not fall back to "reveal all".
+        let data = secret_data(
+            secret(&[("password", b"hunter2")], Some("Opaque")),
+            &["nonexistent".to_string()],
+        );
+        assert!(data.keys.iter().all(|k| k.value.is_none()));
+    }
+
+    #[test]
+    fn a_binary_secret_value_is_never_rendered_even_when_revealed() {
+        // A TLS key in DER form. Asking for it explicitly still gets
+        // nothing back, because there is nothing legible to show and a
+        // screen of replacement characters reads as corruption.
+        let data = secret_data(
+            secret(
+                &[("tls.key", &[0xff, 0xfe, 0x00, 0x01])],
+                Some("kubernetes.io/tls"),
+            ),
+            &["tls.key".to_string()],
+        );
+        let key = &data.keys[0];
+        assert!(key.binary);
+        assert_eq!(key.value, None);
+        assert_eq!(key.bytes, 4);
+    }
+
+    #[test]
+    fn an_empty_secret_is_described_rather_than_refused() {
+        let data = secret_data(Secret::default(), &[]);
+        assert!(data.keys.is_empty());
+        assert!(data.redacted, "an empty Secret is still a Secret");
+        assert_eq!(data.type_, None);
+    }
+
+    #[test]
+    fn a_configmap_shows_every_value_outright() {
+        // The counterpart to the Secret rule. A ConfigMap holds nothing
+        // to hide, and making people click Reveal per key would be
+        // friction with no security behind it.
+        let cm = ConfigMap {
+            data: Some(
+                [
+                    ("log_level".to_string(), "debug".to_string()),
+                    ("timeout".to_string(), "30s".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+            ..Default::default()
+        };
+
+        let data = config_map_data(cm);
+        assert!(!data.redacted);
+        assert_eq!(data.type_, None, "only Secrets carry a type");
+        assert!(data.keys.iter().all(|k| k.value.is_some()));
+        assert_eq!(key_names(&data), vec!["log_level", "timeout"]);
+    }
+
+    #[test]
+    fn configmap_binary_data_is_listed_alongside_the_text_keys() {
+        // binaryData is a separate map in the API. A key that only
+        // appears in it would otherwise be invisible in the tab, and
+        // "the key is missing" is a worse answer than "it is binary".
+        let cm = ConfigMap {
+            data: Some(
+                [("app.conf".to_string(), "listen=80".to_string())]
+                    .into_iter()
+                    .collect(),
+            ),
+            binary_data: Some(
+                [(
+                    "truststore.jks".to_string(),
+                    k8s_openapi::ByteString(vec![0xca, 0xfe, 0xba, 0xbe]),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            ..Default::default()
+        };
+
+        let data = config_map_data(cm);
+        // Sorted together, so the tab reads as one list of keys.
+        assert_eq!(key_names(&data), vec!["app.conf", "truststore.jks"]);
+        let jks = data
+            .keys
+            .iter()
+            .find(|k| k.key == "truststore.jks")
+            .unwrap();
+        assert!(jks.binary);
+        assert_eq!(jks.value, None);
+        assert_eq!(jks.bytes, 4);
+    }
+
+    #[test]
+    fn redaction_does_not_depend_on_the_value_being_valid_base64() {
+        // `redact` runs over the raw JSON, before anything decodes it. A
+        // hand-edited or malformed Secret must still be redacted — the
+        // failure mode to avoid is "unparseable, so printed as-is".
+        let mut object = serde_json::json!({
+            "kind": "Secret",
+            "data": {"password": "!!!not base64!!!"}
+        });
+        redact(&mut object);
+        assert_eq!(object["data"]["password"], REDACTED);
+    }
+
+    #[test]
+    fn the_placeholder_does_not_vary_with_the_value_it_replaces() {
+        // A placeholder proportional to the real value would leak its
+        // length, which for a password is worth something to an attacker.
+        let mut short = serde_json::json!({"data": {"k": "YQ=="}});
+        let mut long =
+            serde_json::json!({"data": {"k": "aHVudGVyMmh1bnRlcjJodW50ZXIyaHVudGVyMg=="}});
+        redact(&mut short);
+        redact(&mut long);
+        assert_eq!(short["data"]["k"], long["data"]["k"]);
     }
 
     #[test]

--- a/src-tauri/src/cluster/detail/namespace.rs
+++ b/src-tauri/src/cluster/detail/namespace.rs
@@ -126,10 +126,7 @@ fn quota_views(quotas: Vec<ResourceQuota>) -> Vec<QuotaView> {
 pub async fn get_namespace(session: &Session, name: &str) -> Result<NamespaceDetail> {
     let client = session.client().await?;
     let api: Api<Namespace> = Api::all(client.clone());
-    let mut ns = api.get(name).await?;
-    ns.metadata.managed_fields = None;
-
-    let yaml = to_yaml(&ns)?;
+    let ns = api.get(name).await?;
 
     let pods: Api<Pod> = Api::namespaced(client.clone(), name);
     let pod_list = pods.list(&ListParams::default()).await?.items;
@@ -141,8 +138,26 @@ pub async fn get_namespace(session: &Session, name: &str) -> Result<NamespaceDet
     let quotas = quotas
         .list(&ListParams::default())
         .await
-        .map(|l| quota_views(l.items))
+        .map(|l| l.items)
         .unwrap_or_default();
+
+    namespace_detail_from(ns, &pod_list, quotas)
+}
+
+/// Builds the namespace detail from the namespace and its contents.
+///
+/// Split from the fetch so the two things this page exists to answer —
+/// what is unhealthy inside, and what is capping it — can be tested
+/// without a cluster.
+pub(crate) fn namespace_detail_from(
+    mut ns: Namespace,
+    pod_list: &[Pod],
+    quotas: Vec<ResourceQuota>,
+) -> Result<NamespaceDetail> {
+    ns.metadata.managed_fields = None;
+
+    let yaml = to_yaml(&ns)?;
+    let quotas = quota_views(quotas);
 
     Ok(NamespaceDetail {
         api_version: "v1".into(),
@@ -157,7 +172,7 @@ pub async fn get_namespace(session: &Session, name: &str) -> Result<NamespaceDet
         annotations: sorted_pairs(ns.annotations()),
         finalizers: ns.finalizers().to_vec(),
         pod_count: pod_list.len(),
-        pods_by_phase: tally(&pod_list),
+        pods_by_phase: tally(pod_list),
         quotas,
         name: ns.name_any(),
         yaml,
@@ -254,6 +269,94 @@ mod tests {
             .find(|e| e.resource == "pods")
             .unwrap();
         assert_eq!(pods.used, "3");
+    }
+
+    fn namespace(name: &str, phase: Option<&str>) -> Namespace {
+        Namespace {
+            metadata: kube::core::ObjectMeta {
+                name: Some(name.into()),
+                ..Default::default()
+            },
+            status: Some(k8s_openapi::api::core::v1::NamespaceStatus {
+                phase: phase.map(str::to_string),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_stuck_terminating_namespace_shows_the_finalizer_holding_it() {
+        // A namespace that will not go away is always a finalizer nobody
+        // is answering for, and naming it is the entire diagnosis.
+        let mut ns = namespace("doomed", Some("Terminating"));
+        ns.spec = Some(k8s_openapi::api::core::v1::NamespaceSpec {
+            finalizers: Some(vec!["kubernetes".into()]),
+        });
+        ns.metadata.finalizers = Some(vec!["custom.io/cleanup".into()]);
+
+        let detail = namespace_detail_from(ns, &[], Vec::new()).expect("build detail");
+        assert_eq!(detail.phase, "Terminating");
+        assert_eq!(detail.finalizers, vec!["custom.io/cleanup"]);
+    }
+
+    #[test]
+    fn the_tally_always_adds_up_to_the_count_beside_it() {
+        // These two numbers sit next to each other on the page. If they
+        // disagree the page is visibly wrong, whichever one is right.
+        let pods = vec![
+            pod(Some("Running")),
+            pod(Some("Running")),
+            pod(Some("Failed")),
+            pod(None),
+            pod(Some("SomethingNew")),
+        ];
+
+        let detail = namespace_detail_from(namespace("prod", Some("Active")), &pods, Vec::new())
+            .expect("build detail");
+
+        assert_eq!(detail.pod_count, 5);
+        assert_eq!(
+            detail.pods_by_phase.iter().map(|t| t.count).sum::<usize>(),
+            detail.pod_count
+        );
+        // Failed leads: it is what the namespace was opened to find.
+        assert_eq!(detail.pods_by_phase[0].phase, "Failed");
+    }
+
+    #[test]
+    fn an_empty_namespace_reports_no_pods_and_no_quotas() {
+        let detail = namespace_detail_from(namespace("empty", Some("Active")), &[], Vec::new())
+            .expect("build detail");
+        assert_eq!(detail.pod_count, 0);
+        assert!(detail.pods_by_phase.is_empty(), "no rows of zeroes");
+        assert!(detail.quotas.is_empty());
+        assert!(detail.finalizers.is_empty());
+    }
+
+    #[test]
+    fn namespace_detail_carries_its_identity_and_strips_managed_fields() {
+        let mut ns = namespace("prod", Some("Active"));
+        ns.metadata.managed_fields = Some(vec![
+            k8s_openapi::apimachinery::pkg::apis::meta::v1::ManagedFieldsEntry {
+                manager: Some("kube-apiserver".into()),
+                ..Default::default()
+            },
+        ]);
+
+        let detail = namespace_detail_from(ns, &[], Vec::new()).expect("build detail");
+        assert_eq!(detail.api_version, "v1");
+        assert_eq!(detail.kind, "Namespace");
+        assert_eq!(detail.name, "prod");
+        assert!(detail.yaml.contains("kind: Namespace"));
+        assert!(!detail.yaml.contains("managedFields"));
+    }
+
+    #[test]
+    fn a_namespace_with_no_status_reads_as_unknown() {
+        let detail =
+            namespace_detail_from(namespace("odd", None), &[], Vec::new()).expect("build detail");
+        assert_eq!(detail.phase, "Unknown");
     }
 
     #[test]

--- a/src-tauri/src/cluster/detail/node.rs
+++ b/src-tauri/src/cluster/detail/node.rs
@@ -302,10 +302,7 @@ fn quantities(
 pub async fn get_node(session: &Session, name: &str) -> Result<NodeDetail> {
     let client = session.client().await?;
     let api: Api<Node> = Api::all(client.clone());
-    let mut node = api.get(name).await?;
-    node.metadata.managed_fields = None;
-
-    let yaml = to_yaml(&node)?;
+    let node = api.get(name).await?;
 
     // Pods are fetched server-side by node, not filtered client-side
     // from a cluster-wide listing: on a large cluster the difference is
@@ -315,6 +312,19 @@ pub async fn get_node(session: &Session, name: &str) -> Result<NodeDetail> {
         .list(&ListParams::default().fields(&format!("spec.nodeName={name}")))
         .await?
         .items;
+
+    node_detail_from(node, &scheduled)
+}
+
+/// Builds the node detail from the node and the pods scheduled onto it.
+///
+/// Split from the fetch so the parts an operator reads when nothing will
+/// schedule — taints, cordon state, allocation against allocatable — can
+/// be tested against constructed nodes.
+pub(crate) fn node_detail_from(mut node: Node, scheduled: &[Pod]) -> Result<NodeDetail> {
+    node.metadata.managed_fields = None;
+
+    let yaml = to_yaml(&node)?;
 
     let status = node.status.clone();
     let info = status.as_ref().and_then(|s| s.node_info.as_ref());
@@ -357,7 +367,7 @@ pub async fn get_node(session: &Session, name: &str) -> Result<NodeDetail> {
         operating_system: info.map(|i| i.operating_system.clone()),
         capacity: quantities(status.as_ref().and_then(|s| s.capacity.as_ref())),
         allocatable: quantities(allocatable),
-        allocated: allocated_from(&scheduled, alloc_cpu, alloc_mem),
+        allocated: allocated_from(scheduled, alloc_cpu, alloc_mem),
         taints: node
             .spec
             .as_ref()
@@ -553,6 +563,220 @@ mod tests {
         let usage = allocated_from(&pods, None, None);
         assert_eq!(usage[0].requests_percent, None);
         assert_eq!(usage[0].allocatable, "—");
+    }
+
+    /// A node with the shape the detail view reads: capacity, a Ready
+    /// condition, and the labels roles come from.
+    fn node(name: &str) -> Node {
+        use k8s_openapi::api::core::v1::{NodeCondition, NodeStatus, NodeSystemInfo};
+
+        let quantities = |cpu: &str, mem: &str| {
+            let mut m = std::collections::BTreeMap::new();
+            m.insert("cpu".to_string(), Quantity(cpu.into()));
+            m.insert("memory".to_string(), Quantity(mem.into()));
+            m
+        };
+
+        Node {
+            metadata: kube::core::ObjectMeta {
+                name: Some(name.into()),
+                labels: Some(
+                    [("node-role.kubernetes.io/worker", "")]
+                        .into_iter()
+                        .map(|(k, v)| (k.to_string(), v.to_string()))
+                        .collect(),
+                ),
+                ..Default::default()
+            },
+            status: Some(NodeStatus {
+                capacity: Some(quantities("8", "16Gi")),
+                allocatable: Some(quantities("7800m", "15Gi")),
+                conditions: Some(vec![NodeCondition {
+                    type_: "Ready".into(),
+                    status: "True".into(),
+                    ..Default::default()
+                }]),
+                node_info: Some(NodeSystemInfo {
+                    kubelet_version: "v1.33.1".into(),
+                    os_image: "Debian GNU/Linux 12".into(),
+                    architecture: "arm64".into(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_cordoned_node_is_still_ready_but_not_schedulable() {
+        // The pair is the whole explanation for "why is nothing landing
+        // here". Collapsing them into one flag loses the answer:
+        // `kubectl cordon` does not make a node unhealthy.
+        let mut cordoned = node("worker-1");
+        cordoned.spec = Some(k8s_openapi::api::core::v1::NodeSpec {
+            unschedulable: Some(true),
+            ..Default::default()
+        });
+
+        let detail = node_detail_from(cordoned, &[]).expect("build detail");
+        assert!(detail.ready, "cordoning does not make a node unhealthy");
+        assert!(!detail.schedulable);
+    }
+
+    #[test]
+    fn a_node_with_no_spec_is_schedulable() {
+        // `unschedulable` absent means schedulable. Defaulting the other
+        // way would show every healthy node as cordoned.
+        let detail = node_detail_from(node("worker-1"), &[]).expect("build detail");
+        assert!(detail.schedulable);
+        assert!(detail.ready);
+        assert_eq!(detail.roles, vec!["worker"]);
+        assert_eq!(detail.version, "v1.33.1");
+        assert_eq!(detail.architecture.as_deref(), Some("arm64"));
+    }
+
+    #[test]
+    fn taints_render_the_way_they_are_written() {
+        // The form they are applied in, so what the page shows can be
+        // pasted back into a toleration.
+        use k8s_openapi::api::core::v1::{NodeSpec, Taint};
+
+        let mut tainted = node("worker-1");
+        tainted.spec = Some(NodeSpec {
+            taints: Some(vec![
+                Taint {
+                    key: "dedicated".into(),
+                    value: Some("gpu".into()),
+                    effect: "NoSchedule".into(),
+                    ..Default::default()
+                },
+                // A valueless taint is common — the control-plane one is
+                // exactly this shape — and "key=:Effect" would be wrong.
+                Taint {
+                    key: "node.kubernetes.io/unreachable".into(),
+                    value: None,
+                    effect: "NoExecute".into(),
+                    ..Default::default()
+                },
+            ]),
+            ..Default::default()
+        });
+
+        let detail = node_detail_from(tainted, &[]).expect("build detail");
+        assert_eq!(
+            detail.taints,
+            vec![
+                "dedicated=gpu:NoSchedule",
+                "node.kubernetes.io/unreachable:NoExecute"
+            ]
+        );
+    }
+
+    #[test]
+    fn allocation_is_measured_against_allocatable_not_capacity() {
+        // The kubelet reserves part of the machine for itself and the
+        // scheduler only hands out what is left. Measuring against
+        // capacity would flatter every node — here 4 of 8 cores reads as
+        // 50%, when the scheduler only has 7.8 to give.
+        let pods = vec![pod("Running", vec![container("4", "4Gi")], vec![])];
+        let detail = node_detail_from(node("worker-1"), &pods).expect("build detail");
+
+        let cpu = detail.allocated.iter().find(|u| u.name == "CPU").unwrap();
+        assert_eq!(cpu.allocatable, "7800m");
+        assert_eq!(
+            cpu.requests_percent,
+            Some(51),
+            "4 cores of 7.8 allocatable, not of 8 capacity"
+        );
+        assert_eq!(detail.pod_count, 1);
+        // Capacity is still reported, just not what percentages are of.
+        assert!(detail.capacity.iter().any(|(k, v)| k == "cpu" && v == "8"));
+    }
+
+    #[test]
+    fn a_node_with_nothing_scheduled_reports_zero_rather_than_nothing() {
+        // An empty node still has rows: "0 of 7800m" is information,
+        // whereas a missing table reads as a failure to load.
+        let detail = node_detail_from(node("worker-1"), &[]).expect("build detail");
+        assert_eq!(detail.pod_count, 0);
+        assert_eq!(detail.allocated.len(), 2, "CPU and Memory");
+        assert_eq!(detail.allocated[0].requests_percent, Some(0));
+    }
+
+    #[test]
+    fn node_detail_strips_managed_fields_and_carries_its_identity() {
+        let mut noisy = node("worker-1");
+        noisy.metadata.managed_fields = Some(vec![
+            k8s_openapi::apimachinery::pkg::apis::meta::v1::ManagedFieldsEntry {
+                manager: Some("kubelet".into()),
+                ..Default::default()
+            },
+        ]);
+
+        let detail = node_detail_from(noisy, &[]).expect("build detail");
+        assert!(!detail.yaml.contains("managedFields"));
+        assert_eq!(detail.api_version, "v1");
+        assert_eq!(detail.kind, "Node");
+        assert_eq!(detail.name, "worker-1");
+    }
+
+    #[test]
+    fn a_node_reporting_no_status_still_renders() {
+        // A node mid-registration. Every optional field is absent, and
+        // the page has to degrade rather than fail.
+        let bare = Node {
+            metadata: kube::core::ObjectMeta {
+                name: Some("joining".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let detail = node_detail_from(bare, &[]).expect("build detail");
+        assert!(!detail.ready);
+        assert!(detail.schedulable);
+        assert!(detail.conditions.is_empty());
+        assert!(detail.addresses.is_empty());
+        assert!(detail.capacity.is_empty());
+        assert_eq!(detail.os_image, None);
+        // The allocation table still exists, with nothing known to
+        // measure against.
+        assert_eq!(detail.allocated[0].allocatable, "—");
+    }
+
+    #[test]
+    fn conditions_carry_the_reason_that_explains_the_pressure() {
+        // "MemoryPressure=True" says the node is under pressure;
+        // the reason says which threshold tripped, and that is what
+        // decides what to do about it.
+        use k8s_openapi::api::core::v1::{NodeCondition, NodeStatus};
+
+        let mut pressured = node("worker-1");
+        pressured.status = Some(NodeStatus {
+            conditions: Some(vec![NodeCondition {
+                type_: "MemoryPressure".into(),
+                status: "True".into(),
+                reason: Some("KubeletHasInsufficientMemory".into()),
+                message: Some("kubelet has insufficient memory available".into()),
+                ..Default::default()
+            }]),
+            ..pressured.status.unwrap()
+        });
+
+        let detail = node_detail_from(pressured, &[]).expect("build detail");
+        let pressure = detail
+            .conditions
+            .iter()
+            .find(|c| c.type_ == "MemoryPressure")
+            .expect("condition should survive");
+        assert_eq!(
+            pressure.reason.as_deref(),
+            Some("KubeletHasInsufficientMemory")
+        );
+        assert!(pressure.message.is_some());
+        // No Ready condition in this status, so the node is not Ready.
+        assert!(!detail.ready);
     }
 
     #[tokio::test]

--- a/src-tauri/src/cluster/detail/pod.rs
+++ b/src-tauri/src/cluster/detail/pod.rs
@@ -98,11 +98,13 @@ fn containers_from(
         .unwrap_or_default()
 }
 
-pub async fn get_pod(session: &Session, namespace: &str, name: &str) -> Result<PodDetail> {
-    let client = session.client().await?;
-    let api: Api<Pod> = Api::namespaced(client, namespace);
-    let mut pod = api.get(name).await?;
-
+/// Builds the detail payload from a fetched pod.
+///
+/// Split from `get_pod` so the flattening — which is where the fields an
+/// operator reads during an incident are decided — can be tested against
+/// constructed pods rather than only whatever a live cluster happens to
+/// be running.
+pub(crate) fn pod_detail_from(mut pod: Pod) -> Result<PodDetail> {
     // managedFields is server-side bookkeeping: dozens of lines that
     // push the interesting spec off the screen and that nobody reads.
     pod.metadata.managed_fields = None;
@@ -152,6 +154,12 @@ pub async fn get_pod(session: &Session, namespace: &str, name: &str) -> Result<P
     })
 }
 
+pub async fn get_pod(session: &Session, namespace: &str, name: &str) -> Result<PodDetail> {
+    let client = session.client().await?;
+    let api: Api<Pod> = Api::namespaced(client, namespace);
+    pod_detail_from(api.get(name).await?)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -190,6 +198,230 @@ mod tests {
     #[test]
     fn empty_container_state_is_unknown_not_a_panic() {
         assert_eq!(container_state(&ContainerState::default()), "Unknown");
+    }
+
+    #[test]
+    fn a_waiting_container_with_no_reason_still_renders() {
+        // The API may report Waiting before it knows why. "Waiting:"
+        // with nothing after it would read as a truncated string.
+        let state = ContainerState {
+            waiting: Some(ContainerStateWaiting::default()),
+            ..Default::default()
+        };
+        assert_eq!(container_state(&state), "Waiting");
+    }
+
+    #[test]
+    fn a_terminated_container_with_no_reason_keeps_its_exit_code() {
+        // The exit code is the diagnostic when the reason is missing;
+        // dropping it would leave nothing to go on.
+        let state = ContainerState {
+            terminated: Some(ContainerStateTerminated {
+                exit_code: 1,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(container_state(&state), "Terminated: Terminated (exit 1)");
+    }
+
+    #[test]
+    fn running_wins_over_a_stale_waiting_block() {
+        // The API can carry more than one populated block. Running is
+        // checked first because it is the current truth.
+        let state = ContainerState {
+            running: Some(k8s_openapi::api::core::v1::ContainerStateRunning::default()),
+            waiting: Some(ContainerStateWaiting {
+                reason: Some("ContainerCreating".into()),
+                message: None,
+            }),
+            ..Default::default()
+        };
+        assert_eq!(container_state(&state), "Running");
+    }
+
+    /// A container status shaped like a crash-looping container: waiting
+    /// to restart now, OOMKilled a moment ago.
+    fn crashlooping() -> k8s_openapi::api::core::v1::ContainerStatus {
+        k8s_openapi::api::core::v1::ContainerStatus {
+            name: "app".into(),
+            image: "app:1.0".into(),
+            ready: false,
+            restart_count: 7,
+            state: Some(ContainerState {
+                waiting: Some(ContainerStateWaiting {
+                    reason: Some("CrashLoopBackOff".into()),
+                    message: None,
+                }),
+                ..Default::default()
+            }),
+            last_state: Some(ContainerState {
+                terminated: Some(ContainerStateTerminated {
+                    reason: Some("OOMKilled".into()),
+                    exit_code: 137,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_crashlooping_container_reports_both_why_it_waits_and_why_it_died() {
+        // This pairing is the entire diagnosis. CrashLoopBackOff alone
+        // says the container keeps dying; the previous OOMKilled says
+        // why, and without it the next step is guesswork.
+        let views = containers_from(Some(&vec![crashlooping()]));
+        assert_eq!(views.len(), 1);
+        assert_eq!(views[0].state, "Waiting: CrashLoopBackOff");
+        assert_eq!(
+            views[0].last_state.as_deref(),
+            Some("Terminated: OOMKilled (exit 137)")
+        );
+        assert_eq!(views[0].restarts, 7);
+        assert!(!views[0].ready);
+    }
+
+    #[test]
+    fn a_container_on_its_first_run_reports_no_previous_state() {
+        // An empty ContainerState means "never ran before". Rendering it
+        // as "Unknown" would suggest a previous run that failed
+        // mysteriously, which is a worse lie than saying nothing.
+        let status = k8s_openapi::api::core::v1::ContainerStatus {
+            name: "app".into(),
+            image: "app:1.0".into(),
+            ready: true,
+            restart_count: 0,
+            state: Some(ContainerState {
+                running: Some(Default::default()),
+                ..Default::default()
+            }),
+            last_state: Some(ContainerState::default()),
+            ..Default::default()
+        };
+        assert_eq!(containers_from(Some(&vec![status]))[0].last_state, None);
+    }
+
+    #[test]
+    fn a_pod_with_no_container_statuses_yields_no_container_rows() {
+        assert!(containers_from(None).is_empty());
+    }
+
+    #[test]
+    fn detail_separates_init_containers_from_app_containers() {
+        // An init container stuck pulling its image is a common reason a
+        // pod never starts, and merging the two lists would hide which
+        // phase the pod is actually stuck in.
+        let pod = Pod {
+            metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                name: Some("web".into()),
+                namespace: Some("prod".into()),
+                ..Default::default()
+            },
+            status: Some(k8s_openapi::api::core::v1::PodStatus {
+                phase: Some("Pending".into()),
+                init_container_statuses: Some(vec![k8s_openapi::api::core::v1::ContainerStatus {
+                    name: "migrate".into(),
+                    image: "migrate:1.0".into(),
+                    ready: false,
+                    restart_count: 0,
+                    state: Some(ContainerState {
+                        waiting: Some(ContainerStateWaiting {
+                            reason: Some("ImagePullBackOff".into()),
+                            message: None,
+                        }),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }]),
+                container_statuses: Some(vec![crashlooping()]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let detail = pod_detail_from(pod).expect("build detail");
+        assert_eq!(detail.init_containers.len(), 1);
+        assert_eq!(detail.init_containers[0].name, "migrate");
+        assert_eq!(detail.init_containers[0].state, "Waiting: ImagePullBackOff");
+        assert_eq!(detail.containers.len(), 1);
+        assert_eq!(detail.containers[0].name, "app");
+    }
+
+    #[test]
+    fn detail_carries_the_identity_the_yaml_editor_saves_against() {
+        // The editor reads apiVersion/kind off the payload rather than
+        // hardcoding them, so every detail view saves the same way. If
+        // these are wrong the save targets the wrong endpoint.
+        let pod = Pod {
+            metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                name: Some("web".into()),
+                namespace: Some("prod".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let detail = pod_detail_from(pod).expect("build detail");
+        assert_eq!(detail.api_version, "v1");
+        assert_eq!(detail.kind, "Pod");
+        assert_eq!(detail.name, "web");
+        assert_eq!(detail.namespace, "prod");
+        // No status at all, which is a pod between creation and
+        // scheduling — not a reason to fail the whole view.
+        assert_eq!(detail.phase, "Unknown");
+        assert!(detail.containers.is_empty());
+    }
+
+    #[test]
+    fn managed_fields_are_stripped_from_the_rendered_yaml() {
+        // Dozens of lines of server-side bookkeeping that push the spec
+        // off the screen. This is the assertion the live test makes too,
+        // pinned here so it holds without a cluster.
+        let pod = Pod {
+            metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                name: Some("web".into()),
+                managed_fields: Some(vec![
+                    k8s_openapi::apimachinery::pkg::apis::meta::v1::ManagedFieldsEntry {
+                        manager: Some("kubectl-client-side-apply".into()),
+                        operation: Some("Update".into()),
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let detail = pod_detail_from(pod).expect("build detail");
+        assert!(!detail.yaml.contains("managedFields"));
+        assert!(!detail.yaml.contains("kubectl-client-side-apply"));
+        assert!(detail.yaml.contains("name: web"));
+    }
+
+    #[test]
+    fn labels_and_annotations_are_ordered_so_the_view_does_not_shuffle() {
+        // Both come off a BTreeMap, so the order is already stable — this
+        // pins it, because a HashMap here would make the detail page
+        // reorder itself on every refresh.
+        let pod = Pod {
+            metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                name: Some("web".into()),
+                labels: Some(
+                    [("zone", "b"), ("app", "web"), ("tier", "front")]
+                        .into_iter()
+                        .map(|(k, v)| (k.to_string(), v.to_string()))
+                        .collect(),
+                ),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let detail = pod_detail_from(pod).expect("build detail");
+        let keys: Vec<&str> = detail.labels.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(keys, vec!["app", "tier", "zone"]);
     }
 
     /// Fetches a real pod and its events.

--- a/src-tauri/src/cluster/discovery.rs
+++ b/src-tauri/src/cluster/discovery.rs
@@ -131,22 +131,33 @@ fn describe(gvk: &GvkRef) -> String {
     }
 }
 
-/// Builds an `Api` for a dynamic kind, respecting its scope.
+/// Which namespace a request should actually be scoped to.
 ///
-/// Asking for a namespace on a cluster-scoped kind would produce a URL
-/// the API server 404s on, so the resource's own scope wins over the
-/// caller's request.
+/// The resource's own scope wins over the caller's request: asking for a
+/// namespace on a cluster-scoped kind builds a URL the API server 404s
+/// on. An empty string is treated as "all namespaces" because that is
+/// what the frontend's namespace picker sends for its "All" option.
+///
+/// Shared with the server-side printing path so a listing and its table
+/// can never disagree about which URL they are talking to.
+pub(crate) fn scoped_namespace(namespaced: bool, requested: Option<&str>) -> Option<&str> {
+    match (namespaced, requested) {
+        (true, Some(ns)) if !ns.is_empty() => Some(ns),
+        _ => None,
+    }
+}
+
+/// Builds an `Api` for a dynamic kind, respecting its scope.
 pub(crate) fn api_for(
     client: kube::Client,
     resource: &ApiResource,
     caps: &ApiCapabilities,
     namespace: Option<&str>,
 ) -> Api<DynamicObject> {
-    match (caps.scope.clone(), namespace) {
-        (Scope::Namespaced, Some(ns)) if !ns.is_empty() => {
-            Api::namespaced_with(client, ns, resource)
-        }
-        _ => Api::all_with(client, resource),
+    let namespaced = matches!(caps.scope, Scope::Namespaced);
+    match scoped_namespace(namespaced, namespace) {
+        Some(ns) => Api::namespaced_with(client, ns, resource),
+        None => Api::all_with(client, resource),
     }
 }
 
@@ -259,15 +270,16 @@ pub async fn list_objects(
     let api = api_for(client, &resource, &caps, namespace.as_deref());
 
     let list = api.list(&ListParams::default()).await?;
-    Ok(list
-        .into_iter()
-        .map(|obj| ObjectSummary {
-            age: age(&obj),
-            status: summarise_status(&obj.data),
-            name: obj.name_any(),
-            namespace: obj.namespace(),
-        })
-        .collect())
+    Ok(list.into_iter().map(summarise_object).collect())
+}
+
+fn summarise_object(obj: DynamicObject) -> ObjectSummary {
+    ObjectSummary {
+        age: age(&obj),
+        status: summarise_status(&obj.data),
+        name: obj.name_any(),
+        namespace: obj.namespace(),
+    }
 }
 
 pub async fn get_object(
@@ -280,14 +292,36 @@ pub async fn get_object(
     let (resource, caps) = resolve(session, &gvk).await?;
     let api = api_for(client, &resource, &caps, namespace.as_deref());
 
-    let mut obj = api.get(name).await?;
+    object_detail_from(
+        api.get(name).await?,
+        &resource.api_version,
+        &resource.kind,
+        caps.supports_operation("update"),
+    )
+}
+
+/// Builds the detail payload for an object of unknown shape.
+///
+/// Split from `get_object` because two of the decisions here are
+/// security-relevant — whether a Secret's values are redacted, and
+/// whether the result may be edited — and both should be provable
+/// without needing a cluster that happens to hold a Secret.
+///
+/// `updatable` is what the API server says about the *kind*; whether
+/// this particular object ends up editable is decided below.
+pub(crate) fn object_detail_from(
+    mut obj: DynamicObject,
+    api_version: &str,
+    kind: &str,
+    updatable: bool,
+) -> Result<ObjectDetail> {
     obj.metadata.managed_fields = None;
 
     // A Secret's values are base64 in the API, which is an encoding and
     // not a protection: rendering the YAML as-is would put every
     // credential on screen. Redacted here rather than in a separate
     // Secret-only path, so there is no generic route that bypasses it.
-    let redacted = crate::cluster::data::is_secret(&resource.api_version, &resource.kind);
+    let redacted = crate::cluster::data::is_secret(api_version, kind);
     if redacted {
         crate::cluster::data::redact(&mut obj.data);
     }
@@ -295,15 +329,15 @@ pub async fn get_object(
     // no `types`, and YAML without apiVersion/kind is not re-appliable —
     // which matters because the editor round-trips exactly this text.
     obj.types = Some(kube::core::TypeMeta {
-        api_version: resource.api_version.clone(),
-        kind: resource.kind.clone(),
+        api_version: api_version.to_string(),
+        kind: kind.to_string(),
     });
 
     let yaml = to_yaml(&obj)?;
 
     Ok(ObjectDetail {
-        api_version: resource.api_version.clone(),
-        kind: resource.kind.clone(),
+        api_version: api_version.to_string(),
+        kind: kind.to_string(),
         age: age(&obj),
         status: summarise_status(&obj.data),
         labels: sorted_pairs(obj.labels()),
@@ -311,7 +345,7 @@ pub async fn get_object(
         conditions: conditions_from(&obj.data),
         // Never offer to apply text whose values have been replaced:
         // saving it would write the placeholder over the real secret.
-        editable: caps.supports_operation("update") && !redacted,
+        editable: updatable && !redacted,
         name: obj.name_any(),
         namespace: obj.namespace(),
         yaml,
@@ -422,6 +456,189 @@ mod tests {
     fn a_condition_without_a_type_is_dropped() {
         let obj = json!({"status": {"conditions": [{"status": "True"}]}});
         assert!(conditions_from(&obj).is_empty());
+    }
+
+    /// Builds an untyped object the way the API server hands one back.
+    fn object(name: &str, namespace: Option<&str>, data: serde_json::Value) -> DynamicObject {
+        DynamicObject {
+            types: None,
+            metadata: kube::core::ObjectMeta {
+                name: Some(name.into()),
+                namespace: namespace.map(str::to_string),
+                ..Default::default()
+            },
+            data,
+        }
+    }
+
+    #[test]
+    fn a_kind_the_cluster_does_not_serve_is_named_in_full() {
+        // The error is the whole diagnosis for "why can Loupe not see my
+        // CRD" — it has to say which group/version it looked for.
+        assert_eq!(
+            describe(&GvkRef {
+                group: "cert-manager.io".into(),
+                version: "v1".into(),
+                kind: "Certificate".into()
+            }),
+            "Certificate (cert-manager.io/v1)"
+        );
+        // A core kind has no group, and printing "Pod (/v1)" would look
+        // like a bug rather than like the core group.
+        assert_eq!(
+            describe(&GvkRef {
+                group: String::new(),
+                version: "v1".into(),
+                kind: "Pod".into()
+            }),
+            "Pod (v1)"
+        );
+    }
+
+    #[test]
+    fn a_cluster_scoped_kind_ignores_a_requested_namespace() {
+        // Nodes are cluster-scoped. Honouring a namespace here builds
+        // /api/v1/namespaces/default/nodes, which the API server 404s.
+        assert_eq!(scoped_namespace(false, Some("kube-system")), None);
+    }
+
+    #[test]
+    fn an_empty_namespace_means_all_namespaces() {
+        // What the namespace picker's "All" option sends. Treating it as
+        // a real namespace would request a namespace literally named "".
+        assert_eq!(scoped_namespace(true, Some("")), None);
+        assert_eq!(scoped_namespace(true, None), None);
+        assert_eq!(scoped_namespace(true, Some("prod")), Some("prod"));
+    }
+
+    #[test]
+    fn a_secret_is_redacted_and_made_read_only_on_the_generic_path() {
+        // The route an operator actually takes to a Secret is the same
+        // generic detail view every other kind uses. If the redaction
+        // lived only in a Secret-specific path, this route would print
+        // every credential — so it is asserted here, on the generic one.
+        let detail = object_detail_from(
+            object(
+                "db-credentials",
+                Some("prod"),
+                json!({"data": {"password": "aHVudGVyMg=="}, "type": "Opaque"}),
+            ),
+            "v1",
+            "Secret",
+            true,
+        )
+        .expect("build detail");
+
+        assert!(
+            !detail.yaml.contains("aHVudGVyMg=="),
+            "the YAML tab must not carry the value: {}",
+            detail.yaml
+        );
+        assert!(detail.yaml.contains("redacted"));
+        // Applying redacted text would write the placeholder over every
+        // real value — a worse outcome than not being able to edit here.
+        assert!(
+            !detail.editable,
+            "redacted YAML must never be offered for editing"
+        );
+    }
+
+    #[test]
+    fn a_configmap_on_the_same_path_is_not_redacted() {
+        // The counterpart. Redacting everything would be safe and
+        // useless; the rule has to be specific to Secrets.
+        let detail = object_detail_from(
+            object(
+                "app-config",
+                Some("prod"),
+                json!({"data": {"log_level": "debug"}}),
+            ),
+            "v1",
+            "ConfigMap",
+            true,
+        )
+        .expect("build detail");
+
+        assert!(detail.yaml.contains("debug"));
+        assert!(detail.editable);
+    }
+
+    #[test]
+    fn a_kind_the_server_will_not_update_is_not_editable() {
+        // Offering an Edit button that always fails is worse than not
+        // offering one. This is the RBAC-and-subresource case, distinct
+        // from the redaction case above.
+        let detail = object_detail_from(
+            object("metrics", None, json!({})),
+            "metrics.k8s.io/v1beta1",
+            "NodeMetrics",
+            false,
+        )
+        .expect("build detail");
+        assert!(!detail.editable);
+    }
+
+    #[test]
+    fn detail_yaml_always_carries_apiversion_and_kind() {
+        // A DynamicObject fetched through the typed path comes back with
+        // no `types`. The editor round-trips exactly this text, and YAML
+        // without an apiVersion is not re-appliable.
+        let detail = object_detail_from(
+            object("web", Some("prod"), json!({"spec": {"replicas": 3}})),
+            "apps/v1",
+            "Deployment",
+            true,
+        )
+        .expect("build detail");
+
+        assert!(detail.yaml.contains("apiVersion: apps/v1"));
+        assert!(detail.yaml.contains("kind: Deployment"));
+        assert_eq!(detail.api_version, "apps/v1");
+        assert_eq!(detail.kind, "Deployment");
+        assert_eq!(detail.namespace.as_deref(), Some("prod"));
+    }
+
+    #[test]
+    fn detail_strips_managed_fields_from_an_untyped_object() {
+        let mut obj = object("web", Some("prod"), json!({}));
+        obj.metadata.managed_fields = Some(vec![
+            k8s_openapi::apimachinery::pkg::apis::meta::v1::ManagedFieldsEntry {
+                manager: Some("kube-controller-manager".into()),
+                ..Default::default()
+            },
+        ]);
+
+        let detail = object_detail_from(obj, "apps/v1", "Deployment", true).expect("build detail");
+        assert!(!detail.yaml.contains("managedFields"));
+        assert!(!detail.yaml.contains("kube-controller-manager"));
+    }
+
+    #[test]
+    fn a_listing_and_its_detail_agree_about_status() {
+        // Both read the same object through different functions. If they
+        // diverge, a row says Ready and the page it opens says otherwise.
+        let data = json!({"status": {"conditions": [{"type": "Ready", "status": "True"}]}});
+        let summary = summarise_object(object("thing", Some("prod"), data.clone()));
+        let detail = object_detail_from(
+            object("thing", Some("prod"), data),
+            "x.io/v1",
+            "Thing",
+            true,
+        )
+        .expect("build detail");
+
+        assert_eq!(summary.status.as_deref(), Some("Ready"));
+        assert_eq!(summary.status, detail.status);
+        assert_eq!(summary.name, detail.name);
+        assert_eq!(summary.namespace, detail.namespace);
+    }
+
+    #[test]
+    fn a_cluster_scoped_object_summarises_with_no_namespace() {
+        let summary = summarise_object(object("node-1", None, json!({})));
+        assert_eq!(summary.namespace, None);
+        // No status block at all is a legitimate CRD shape.
+        assert_eq!(summary.status, None);
     }
 
     #[tokio::test]

--- a/src-tauri/src/cluster/edit.rs
+++ b/src-tauri/src/cluster/edit.rs
@@ -169,12 +169,20 @@ fn is_conflict(error: &kube::Error) -> bool {
     }
 }
 
-pub async fn apply_yaml(session: &Session, target: EditTarget, yaml: &str) -> Result<ApplyResult> {
+/// Everything an edit can be rejected for without asking the cluster.
+///
+/// Parsing, the identity checks, and the conversion to an object all
+/// happen here, so the request that eventually goes out is one that has
+/// already been proven to target what the editor was opened on. Split
+/// from `apply_yaml` because this is the half that decides whether a
+/// write is safe, and it should be provable without a cluster to write
+/// to.
+pub(crate) fn prepare(target: &EditTarget, yaml: &str) -> Result<(GvkRef, DynamicObject)> {
     let doc: serde_json::Value = serde_yaml::from_str(yaml)
         .map_err(|e| AppError::InvalidEdit(format!("this is not valid YAML: {e}")))?;
 
     let found = identity_of(&doc)?;
-    check(&target, &found)?;
+    check(target, &found)?;
 
     let (group, version) = split_api_version(&found.api_version)?;
     let gvk = GvkRef {
@@ -182,16 +190,23 @@ pub async fn apply_yaml(session: &Session, target: EditTarget, yaml: &str) -> Re
         version,
         kind: found.kind.clone(),
     };
+
+    let object: DynamicObject = serde_json::from_value(doc)
+        .map_err(|e| AppError::InvalidEdit(format!("this is not a Kubernetes object: {e}")))?;
+
+    Ok((gvk, object))
+}
+
+pub async fn apply_yaml(session: &Session, target: EditTarget, yaml: &str) -> Result<ApplyResult> {
+    let (gvk, object) = prepare(&target, yaml)?;
+
     let (resource, caps) = resolve(session, &gvk).await?;
     if !caps.supports_operation("update") {
         return Err(AppError::InvalidEdit(format!(
             "this cluster does not accept updates to {}",
-            found.kind
+            gvk.kind
         )));
     }
-
-    let object: DynamicObject = serde_json::from_value(doc)
-        .map_err(|e| AppError::InvalidEdit(format!("this is not a Kubernetes object: {e}")))?;
 
     let client = session.client().await?;
     let api = api_for(client, &resource, &caps, target.namespace.as_deref());
@@ -365,6 +380,117 @@ mod tests {
         assert_eq!(found.namespace.as_deref(), Some("default"));
         assert_eq!(found.resource_version.as_deref(), Some("12345"));
         assert_eq!(found.kind, "ConfigMap");
+    }
+
+    /// The document, as the editor would hand it back.
+    fn yaml_of(doc: &serde_json::Value) -> String {
+        serde_yaml::to_string(doc).unwrap()
+    }
+
+    #[test]
+    fn a_valid_edit_resolves_to_the_kind_it_came_from() {
+        let (gvk, object) = prepare(&target(), &yaml_of(&document())).expect("should prepare");
+        // The core group is empty rather than absent; a GvkRef with
+        // group "v1" would resolve to nothing.
+        assert_eq!(gvk.group, "");
+        assert_eq!(gvk.version, "v1");
+        assert_eq!(gvk.kind, "ConfigMap");
+        assert_eq!(object.metadata.name.as_deref(), Some("settings"));
+        assert_eq!(
+            object.metadata.resource_version.as_deref(),
+            Some("12345"),
+            "the resourceVersion has to survive into the request, or the \
+             replace becomes a blind overwrite"
+        );
+    }
+
+    #[test]
+    fn a_grouped_kind_resolves_to_its_own_group() {
+        let doc = json!({
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "web", "namespace": "prod", "resourceVersion": "9"}
+        });
+        let target = EditTarget {
+            api_version: "apps/v1".into(),
+            kind: "Deployment".into(),
+            namespace: Some("prod".into()),
+            name: "web".into(),
+        };
+
+        let (gvk, _) = prepare(&target, &yaml_of(&doc)).expect("should prepare");
+        assert_eq!(gvk.group, "apps");
+        assert_eq!(gvk.version, "v1");
+    }
+
+    #[test]
+    fn a_renamed_document_never_reaches_the_cluster() {
+        // The check that matters most. Kubernetes has no rename, so a
+        // changed name either fails or — for a name that happens to
+        // exist — overwrites a bystander. It has to be caught here,
+        // before anything is sent.
+        let mut doc = document();
+        doc["metadata"]["name"] = json!("something-else");
+
+        let err = prepare(&target(), &yaml_of(&doc)).expect_err("must be refused");
+        assert!(matches!(err, AppError::InvalidEdit(_)));
+        let message = err.to_string();
+        assert!(message.contains("settings"), "{message}");
+        assert!(message.contains("something-else"), "{message}");
+    }
+
+    #[test]
+    fn an_edit_that_moves_namespace_never_reaches_the_cluster() {
+        // Same reasoning as the rename: writing to `kube-system` because
+        // someone edited a line is not an outcome the editor should be
+        // able to produce.
+        let mut doc = document();
+        doc["metadata"]["namespace"] = json!("kube-system");
+        assert!(prepare(&target(), &yaml_of(&doc)).is_err());
+    }
+
+    #[test]
+    fn malformed_yaml_is_refused_before_anything_is_parsed_as_an_object() {
+        let err = prepare(&target(), "kind: : :\n  bad").expect_err("must be refused");
+        assert!(matches!(err, AppError::InvalidEdit(_)));
+        assert!(err.to_string().contains("YAML"), "{err}");
+    }
+
+    #[test]
+    fn a_document_whose_metadata_is_not_a_map_is_refused_rather_than_panicking() {
+        // Hand-edited YAML can produce this. It parses, and it is not an
+        // object we can apply.
+        let doc = json!({"apiVersion": "v1", "kind": "ConfigMap", "metadata": "oops"});
+        assert!(prepare(&target(), &yaml_of(&doc)).is_err());
+    }
+
+    #[test]
+    fn the_api_servers_409_is_recognised_as_a_conflict() {
+        // This is what turns a raw failure into the editor's "reload and
+        // re-apply" path. Matching on the status code rather than on
+        // prose keeps it working across kube versions.
+        // Built the way the API server sends it, so the shape is the
+        // one the client actually parses rather than one made up here.
+        let status = |code: u16, reason: &str| {
+            kube::Error::Api(Box::new(
+                serde_json::from_value(json!({
+                    "status": "Failure",
+                    "code": code,
+                    "reason": reason,
+                    "message": "the object has been modified",
+                }))
+                .expect("parse status"),
+            ))
+        };
+
+        assert!(is_conflict(&status(409, "Conflict")));
+
+        let forbidden = status(403, "Forbidden");
+        assert!(
+            !is_conflict(&forbidden),
+            "an RBAC denial is not a stale-edit conflict, and offering \
+             'reload and retry' for one would send the user in circles"
+        );
     }
 
     /// Round-trips a real edit: read a ConfigMap, change it, apply it,

--- a/src-tauri/src/cluster/helm.rs
+++ b/src-tauri/src/cluster/helm.rs
@@ -300,6 +300,19 @@ pub async fn get_release(session: &Session, namespace: &str, name: &str) -> Resu
         }
     }
 
+    release_detail_from(revisions, namespace, name)
+}
+
+/// Assembles the detail payload from every revision of one release.
+///
+/// Split from `get_release` so the two decisions worth pinning — which
+/// revision leads, and which values are shown — can be tested without a
+/// cluster that happens to have a release installed on it.
+pub(crate) fn release_detail_from(
+    mut revisions: Vec<serde_json::Value>,
+    namespace: &str,
+    name: &str,
+) -> Result<ReleaseDetail> {
     // Newest first: the current revision leads, and the history below it
     // reads backwards in time the way `helm history` prints it.
     revisions.sort_by_key(|r| std::cmp::Reverse(revision_of(r)));
@@ -511,6 +524,114 @@ mod tests {
     fn a_real_timestamp_renders_an_age() {
         let recent = k8s_openapi::jiff::Timestamp::now().to_string();
         assert!(age_of(&recent).is_some());
+    }
+
+    /// The same release at an earlier revision.
+    fn revision_at(version: i64, status: &str) -> serde_json::Value {
+        let mut release = release_json();
+        release["version"] = json!(version);
+        release["info"]["status"] = json!(status);
+        release
+    }
+
+    #[test]
+    fn the_current_revision_leads_however_the_secrets_arrived() {
+        // The API returns Secrets in name order, which puts v10 before
+        // v2. Leading with the wrong one would show a superseded release
+        // as the live one — the worst thing this view could get wrong.
+        let detail = release_detail_from(
+            vec![
+                revision_at(2, "superseded"),
+                revision_at(10, "deployed"),
+                revision_at(1, "superseded"),
+            ],
+            "monitoring",
+            "prom",
+        )
+        .expect("build detail");
+
+        assert_eq!(detail.revision, 10);
+        assert_eq!(detail.status, "deployed");
+        assert_eq!(detail.history[0].revision, 10);
+        assert!(
+            detail
+                .history
+                .windows(2)
+                .all(|w| w[0].revision >= w[1].revision),
+            "history reads backwards in time"
+        );
+    }
+
+    #[test]
+    fn values_show_what_was_overridden_not_the_charts_defaults() {
+        // `config` is the user's overrides; the chart's own defaults live
+        // in chart.values. Showing the defaults would bury the two lines
+        // somebody actually set under a thousand they did not.
+        let detail =
+            release_detail_from(vec![release_json()], "monitoring", "prom").expect("build detail");
+        assert!(detail.values.contains("grafana"));
+        assert!(detail.values.contains("enabled"));
+    }
+
+    #[test]
+    fn a_release_installed_with_no_overrides_shows_empty_values() {
+        // `helm install` with no -f and no --set. Rendering "{}" or
+        // "null" would read as a value someone set.
+        let mut release = release_json();
+        release["config"] = json!({});
+        let detail =
+            release_detail_from(vec![release], "monitoring", "prom").expect("build detail");
+        assert_eq!(detail.values, "");
+
+        let mut null_config = release_json();
+        null_config["config"] = serde_json::Value::Null;
+        let detail =
+            release_detail_from(vec![null_config], "monitoring", "prom").expect("build detail");
+        assert_eq!(detail.values, "");
+    }
+
+    #[test]
+    fn a_release_with_no_readable_revisions_says_so_by_name() {
+        // Reached when every Secret for the name failed to decode. The
+        // error has to name the release and namespace, because the next
+        // question is always "which one".
+        let err = release_detail_from(Vec::new(), "monitoring", "prom")
+            .expect_err("no revisions is an error");
+        let message = err.to_string();
+        assert!(message.contains("prom"), "{message}");
+        assert!(message.contains("monitoring"), "{message}");
+    }
+
+    #[test]
+    fn detail_carries_the_notes_and_chart_metadata_the_view_renders() {
+        let detail =
+            release_detail_from(vec![release_json()], "monitoring", "prom").expect("build detail");
+
+        assert_eq!(detail.chart_name, "kube-prometheus-stack");
+        assert_eq!(detail.chart_version.as_deref(), Some("85.3.3"));
+        assert_eq!(detail.chart, "kube-prometheus-stack-85.3.3");
+        // Usually the only place a chart says how to reach what it
+        // installed, so losing it costs the user the next step.
+        assert_eq!(
+            detail.notes.as_deref(),
+            Some("browse http://localhost:3000")
+        );
+        assert!(detail.manifest.contains("kind: Service"));
+    }
+
+    #[test]
+    fn a_release_whose_payload_omits_its_own_name_falls_back_to_the_secrets() {
+        // The name and namespace were already known from the Secret; a
+        // payload missing them should not produce a detail page titled
+        // with an empty string.
+        let detail = release_detail_from(
+            vec![json!({"version": 1, "info": {"status": "deployed"}})],
+            "monitoring",
+            "prom",
+        )
+        .expect("build detail");
+        assert_eq!(detail.name, "prom");
+        assert_eq!(detail.namespace, "monitoring");
     }
 
     #[tokio::test]

--- a/src-tauri/src/cluster/resources.rs
+++ b/src-tauri/src/cluster/resources.rs
@@ -70,22 +70,22 @@ pub(crate) fn format_age(seconds: i64) -> String {
     }
 }
 
+fn summarise_namespace(ns: Namespace) -> NamespaceSummary {
+    NamespaceSummary {
+        age: age(&ns),
+        name: ns.name_any(),
+        phase: ns
+            .status
+            .and_then(|s| s.phase)
+            .unwrap_or_else(|| "Unknown".into()),
+    }
+}
+
 pub async fn list_namespaces(session: &Session) -> Result<Vec<NamespaceSummary>> {
     let client = session.client().await?;
     let api: Api<Namespace> = Api::all(client);
     let list = api.list(&ListParams::default()).await?;
-
-    Ok(list
-        .into_iter()
-        .map(|ns| NamespaceSummary {
-            age: age(&ns),
-            name: ns.name_any(),
-            phase: ns
-                .status
-                .and_then(|s| s.phase)
-                .unwrap_or_else(|| "Unknown".into()),
-        })
-        .collect())
+    Ok(list.into_iter().map(summarise_namespace).collect())
 }
 
 fn summarise_pod(pod: Pod) -> PodSummary {
@@ -145,33 +145,219 @@ pub async fn list_pods_on_node(session: &Session, node: &str) -> Result<Vec<PodS
         .collect())
 }
 
+fn summarise_node(node: Node) -> NodeSummary {
+    // Roles and readiness are shared with the node detail view so the
+    // list and the page it opens can never disagree about a node.
+    let roles = crate::cluster::detail::node::roles_of(&node);
+    let ready = crate::cluster::detail::node::is_ready(&node);
+
+    let version = node
+        .status
+        .as_ref()
+        .and_then(|s| s.node_info.as_ref())
+        .map(|i| i.kubelet_version.clone())
+        .unwrap_or_default();
+
+    NodeSummary {
+        age: age(&node),
+        name: node.name_any(),
+        ready,
+        roles,
+        version,
+    }
+}
+
 pub async fn list_nodes(session: &Session) -> Result<Vec<NodeSummary>> {
     let client = session.client().await?;
     let api: Api<Node> = Api::all(client);
     let list = api.list(&ListParams::default()).await?;
+    Ok(list.into_iter().map(summarise_node).collect())
+}
 
-    Ok(list
-        .into_iter()
-        .map(|node| {
-            // Shared with the node detail view so the list and the page
-            // it opens can never disagree about a node's roles.
-            let roles = crate::cluster::detail::node::roles_of(&node);
-            let ready = crate::cluster::detail::node::is_ready(&node);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::core::v1::{
+        ContainerStatus, NamespaceStatus, NodeStatus, NodeSystemInfo, PodSpec, PodStatus,
+    };
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ObjectMeta, Time};
 
-            let version = node
-                .status
-                .as_ref()
-                .and_then(|s| s.node_info.as_ref())
-                .map(|i| i.kubelet_version.clone())
-                .unwrap_or_default();
+    fn meta(name: &str) -> ObjectMeta {
+        ObjectMeta {
+            name: Some(name.into()),
+            ..Default::default()
+        }
+    }
 
-            NodeSummary {
-                age: age(&node),
-                name: node.name_any(),
-                ready,
-                roles,
-                version,
-            }
-        })
-        .collect())
+    /// A container status with everything the ready/restart columns read.
+    fn container(name: &str, ready: bool, restarts: i32) -> ContainerStatus {
+        ContainerStatus {
+            name: name.into(),
+            ready,
+            restart_count: restarts,
+            image: "nginx:1.27".into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn age_uses_the_largest_unit_that_still_reads_as_a_number() {
+        // kubectl's shorthand. Each boundary is one second either side,
+        // because an off-by-one here shows "60m" where kubectl shows
+        // "1h" and quietly stops matching the tool people compare against.
+        assert_eq!(format_age(0), "0s");
+        assert_eq!(format_age(59), "59s");
+        assert_eq!(format_age(60), "1m");
+        assert_eq!(format_age(3599), "59m");
+        assert_eq!(format_age(3600), "1h");
+        assert_eq!(format_age(86_399), "23h");
+        assert_eq!(format_age(86_400), "1d");
+        assert_eq!(format_age(86_400 * 400), "400d");
+    }
+
+    #[test]
+    fn an_object_with_no_creation_timestamp_has_no_age() {
+        // Rendering "0s" would claim the object was created just now,
+        // which is a stronger statement than "we do not know".
+        let pod = Pod {
+            metadata: meta("undated"),
+            ..Default::default()
+        };
+        assert_eq!(age(&pod), None);
+    }
+
+    #[test]
+    fn a_creation_timestamp_in_the_future_clamps_to_zero() {
+        // Clock skew between the workstation and the API server is
+        // routine; a node whose age renders as "-3s" reads as a bug in
+        // Loupe rather than as a clock that needs fixing.
+        let future = k8s_openapi::jiff::Timestamp::now().as_second() + 600;
+        let pod = Pod {
+            metadata: ObjectMeta {
+                creation_timestamp: Some(Time(
+                    k8s_openapi::jiff::Timestamp::from_second(future).unwrap(),
+                )),
+                ..meta("skewed")
+            },
+            ..Default::default()
+        };
+        assert_eq!(age(&pod).as_deref(), Some("0s"));
+    }
+
+    #[test]
+    fn ready_counts_only_the_containers_reporting_ready() {
+        // The column every operator reads first. "2/3" and "3/3" are the
+        // difference between a healthy pod and one to investigate.
+        let pod = Pod {
+            metadata: meta("web"),
+            spec: Some(PodSpec {
+                node_name: Some("node-1".into()),
+                ..Default::default()
+            }),
+            status: Some(PodStatus {
+                phase: Some("Running".into()),
+                container_statuses: Some(vec![
+                    container("app", true, 0),
+                    container("sidecar", false, 2),
+                    container("proxy", true, 1),
+                ]),
+                ..Default::default()
+            }),
+        };
+
+        let got = summarise_pod(pod);
+        assert_eq!(got.ready, "2/3");
+        // Restarts are summed across containers: a pod is restarting if
+        // any container is, and the per-container split is on the
+        // detail page rather than in a list column.
+        assert_eq!(got.restarts, 3);
+        assert_eq!(got.node.as_deref(), Some("node-1"));
+        assert_eq!(got.phase, "Running");
+    }
+
+    #[test]
+    fn a_pod_that_has_not_been_scheduled_yet_summarises_without_panicking() {
+        // Between creation and scheduling there is no status and no
+        // node. This is the state a pod is in exactly when someone is
+        // watching the list to see whether it schedules.
+        let pod = Pod {
+            metadata: meta("pending"),
+            ..Default::default()
+        };
+
+        let got = summarise_pod(pod);
+        assert_eq!(got.ready, "0/0");
+        assert_eq!(got.restarts, 0);
+        assert_eq!(got.node, None);
+        // Not "Running", and not an empty cell that reads as a rendering
+        // failure.
+        assert_eq!(got.phase, "Unknown");
+        assert_eq!(got.namespace, "", "an unscoped pod reports no namespace");
+    }
+
+    #[test]
+    fn a_namespace_without_a_status_reads_as_unknown_rather_than_active() {
+        // Guessing "Active" would be the dangerous direction to be wrong
+        // in: a terminating namespace would look healthy.
+        let ns = Namespace {
+            metadata: meta("orphan"),
+            ..Default::default()
+        };
+        assert_eq!(summarise_namespace(ns).phase, "Unknown");
+
+        let terminating = Namespace {
+            metadata: meta("going"),
+            status: Some(NamespaceStatus {
+                phase: Some("Terminating".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(summarise_namespace(terminating).phase, "Terminating");
+    }
+
+    #[test]
+    fn a_node_summary_carries_its_kubelet_version_and_roles() {
+        let node = Node {
+            metadata: ObjectMeta {
+                labels: Some(
+                    [(
+                        "node-role.kubernetes.io/control-plane".to_string(),
+                        String::new(),
+                    )]
+                    .into_iter()
+                    .collect(),
+                ),
+                ..meta("cp-0")
+            },
+            status: Some(NodeStatus {
+                node_info: Some(NodeSystemInfo {
+                    kubelet_version: "v1.33.1".into(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let got = summarise_node(node);
+        assert_eq!(got.name, "cp-0");
+        assert_eq!(got.version, "v1.33.1");
+        assert_eq!(got.roles, vec!["control-plane"]);
+        // No Ready condition at all is not the same as Ready.
+        assert!(!got.ready);
+    }
+
+    #[test]
+    fn a_node_that_reports_no_version_renders_blank_rather_than_failing() {
+        // A node mid-registration has no nodeInfo yet. An empty version
+        // cell is honest; refusing to list the node is not.
+        let node = Node {
+            metadata: meta("joining"),
+            ..Default::default()
+        };
+        let got = summarise_node(node);
+        assert_eq!(got.version, "");
+        assert!(got.roles.is_empty());
+    }
 }

--- a/src-tauri/src/cluster/table.rs
+++ b/src-tauri/src/cluster/table.rs
@@ -20,7 +20,7 @@ use kube::core::{Request, Resource};
 use kube::discovery::Scope;
 use serde::{Deserialize, Serialize};
 
-use crate::cluster::discovery::{resolve, GvkRef};
+use crate::cluster::discovery::{resolve, scoped_namespace, GvkRef};
 use crate::cluster::Session;
 use crate::error::{AppError, Result};
 
@@ -171,12 +171,9 @@ pub async fn list_table(
     let (resource, caps) = resolve(session, &gvk).await?;
 
     let namespaced = matches!(caps.scope, Scope::Namespaced);
-    // The resource's own scope wins: asking for a namespace on a
-    // cluster-scoped kind builds a URL the API server does not serve.
-    let scope = match (namespaced, namespace.as_deref()) {
-        (true, Some(ns)) if !ns.is_empty() => Some(ns),
-        _ => None,
-    };
+    // Same rule the object-listing path uses, so a table and the listing
+    // behind it can never disagree about which URL they are talking to.
+    let scope = scoped_namespace(namespaced, namespace.as_deref());
 
     let url = <kube::api::DynamicObject as Resource>::url_path(&resource, scope);
     let request = Request::new(url)

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -97,3 +97,95 @@ impl Serialize for AppError {
 }
 
 pub type Result<T> = std::result::Result<T, AppError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn serialised(e: AppError) -> serde_json::Value {
+        serde_json::to_value(e).expect("errors must serialise; the IPC boundary requires it")
+    }
+
+    #[test]
+    fn every_error_crosses_the_boundary_as_kind_and_message() {
+        // The frontend branches on `kind` and shows `message`. Anything
+        // else — a bare string, a tagged enum — silently breaks both.
+        let value = serialised(AppError::NotConnected);
+        assert_eq!(value["kind"], "not_connected");
+        assert_eq!(value["message"], "not connected to a cluster");
+        assert_eq!(
+            value.as_object().map(|o| o.len()),
+            Some(2),
+            "exactly two fields: {value}"
+        );
+    }
+
+    #[test]
+    fn the_discriminants_match_what_the_frontend_compares_against() {
+        // These strings are a contract with src/lib/api.ts. Renaming one
+        // here is a silent behaviour change over there — `isConflict`
+        // stops matching and the editor loses its reload-and-retry path.
+        let cases = [
+            (AppError::Kubeconfig("x".into()), "kubeconfig"),
+            (AppError::UnknownContext("x".into()), "unknown_context"),
+            (AppError::NotConnected, "not_connected"),
+            (AppError::UnknownResource("x".into()), "unknown_resource"),
+            (AppError::InvalidEdit("x".into()), "invalid_edit"),
+            (AppError::Conflict("x".into()), "conflict"),
+            (AppError::Settings("x".into()), "settings"),
+            (AppError::Kube("x".into()), "kubernetes"),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(serialised(error)["kind"], expected);
+        }
+    }
+
+    #[test]
+    fn an_rbac_denial_keeps_the_servers_own_wording() {
+        // "forbidden: User cannot list pods in namespace prod" is the
+        // whole answer. Replacing it with a generic "request failed"
+        // turns a solvable permissions problem into a mystery.
+        let message = "pods is forbidden: User \"dev\" cannot list resource \"pods\"";
+        let value = serialised(AppError::Kube(message.into()));
+        assert!(
+            value["message"].as_str().unwrap().contains(message),
+            "got {value}"
+        );
+    }
+
+    #[test]
+    fn a_conflict_carries_its_message_unprefixed() {
+        // The editor shows this text directly next to a "Discard &
+        // reload" button, so a prefix like "kubernetes: " would read as
+        // noise in the one place the wording was written for the user.
+        let value = serialised(AppError::Conflict(
+            "the object was changed in the cluster".into(),
+        ));
+        assert_eq!(value["message"], "the object was changed in the cluster");
+    }
+
+    #[test]
+    fn context_and_settings_errors_say_what_went_wrong() {
+        assert_eq!(
+            AppError::UnknownContext("staging".into()).to_string(),
+            "no such context: staging"
+        );
+        // Prefixed, because this one surfaces in a log rather than in a
+        // dialog written for the user.
+        assert_eq!(
+            AppError::Settings("disk full".into()).to_string(),
+            "settings: disk full"
+        );
+    }
+
+    #[test]
+    fn a_kube_error_converts_rather_than_being_stringified_at_the_call_site() {
+        // `?` on a kube::Error has to land on the Kube variant. If the
+        // From impl were missing, every call site would need its own
+        // map_err and one of them would eventually get it wrong.
+        let err: AppError = kube::Error::LinesCodecMaxLineLengthExceeded.into();
+        assert!(matches!(err, AppError::Kube(_)));
+        assert_eq!(serialised(err)["kind"], "kubernetes");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -265,8 +265,12 @@ struct VibrancyState(bool);
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // No plugins are registered. `tauri-plugin-opener` came with the
+    // scaffold and was never used: it lets the webview ask the OS to
+    // open an arbitrary URL or path, and Loupe renders strings that come
+    // from the cluster — annotations, chart homepages, CRD fields. A
+    // capability nothing needs is one that cannot be misused later.
     tauri::Builder::default()
-        .plugin(tauri_plugin_opener::init())
         .setup(|app| {
             app.manage(SharedSession::default());
             app.manage(VibrancyState(vibrancy::setup(app)));

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -167,8 +167,13 @@ mod tests {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
                 .as_nanos();
+            // Test scaffolding. `create_dir` below rather than
+            // `create_dir_all` so it fails closed: the system temp
+            // directory is shared, and a path something else got to
+            // first should stop the test rather than be written through.
+            // nosemgrep: rust.lang.security.temp-dir.temp-dir
             let dir = std::env::temp_dir().join(format!("loupe-settings-{tag}-{stamp}"));
-            std::fs::create_dir_all(&dir).expect("create scratch dir");
+            std::fs::create_dir(&dir).expect("create scratch dir");
             TempDir(dir)
         }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,8 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' data: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost ws://localhost:1420"
+      "csp": "default-src 'self'; img-src 'self' data: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost",
+      "devCsp": "default-src 'self'; img-src 'self' data: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost ws://localhost:1420"
     },
     "macOSPrivateApi": false
   },

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import App from "./App";
+import { api } from "./lib/api";
+
+// The shell: which screen is showing, and what happens to cached data
+// when the cluster underneath it changes. The cache is the interesting
+// part — rows from the previous cluster appearing under the new one's
+// name would be worse than a slow load.
+
+vi.mock("./lib/api", async (original) => {
+  const actual = await original<typeof import("./lib/api")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      currentCluster: vi.fn(),
+      getSettings: vi.fn(),
+      setTheme: vi.fn(),
+      disconnect: vi.fn(),
+      listContexts: vi.fn(),
+      connect: vi.fn(),
+      listNodes: vi.fn(),
+      listNamespaces: vi.fn(),
+      listPods: vi.fn(),
+      listApiResources: vi.fn(),
+      listHelmReleases: vi.fn(),
+      vibrancyEnabled: vi.fn(),
+    },
+  };
+});
+
+vi.mock("./lib/window", () => ({ dragRegionProps: {} }));
+
+const currentCluster = vi.mocked(api.currentCluster);
+const getSettings = vi.mocked(api.getSettings);
+const setTheme = vi.mocked(api.setTheme);
+const disconnect = vi.mocked(api.disconnect);
+const listContexts = vi.mocked(api.listContexts);
+const listNodes = vi.mocked(api.listNodes);
+
+const CLUSTER = {
+  context: "orbstack",
+  server: "https://127.0.0.1:26443",
+  version: "v1.33.1",
+  platform: "linux/arm64",
+};
+
+/// Tracks the QueryClient so a test can assert the cache was cleared.
+let client: QueryClient;
+
+function renderApp() {
+  client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <App />
+    </QueryClientProvider>,
+  );
+  return userEvent.setup();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // jsdom has no matchMedia, and the theme effect reads it on mount.
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  });
+
+  currentCluster.mockResolvedValue(CLUSTER);
+  getSettings.mockResolvedValue({ theme: "system" });
+  setTheme.mockResolvedValue({ theme: "dark" });
+  disconnect.mockResolvedValue(undefined);
+  listContexts.mockResolvedValue([
+    {
+      name: "orbstack",
+      // Distinct from the context name so a query for one in the picker
+      // is unambiguous.
+      cluster: "orbstack-k8s",
+      user: "orbstack-admin",
+      namespace: null,
+      isCurrent: true,
+    },
+  ]);
+  listNodes.mockResolvedValue([
+    { name: "worker-1", ready: true, roles: [], version: "v1.33.1", age: "1d" },
+  ]);
+  vi.mocked(api.listNamespaces).mockResolvedValue([]);
+  vi.mocked(api.listPods).mockResolvedValue([]);
+  vi.mocked(api.listApiResources).mockResolvedValue([]);
+  vi.mocked(api.listHelmReleases).mockResolvedValue([]);
+  vi.mocked(api.vibrancyEnabled).mockResolvedValue(false);
+});
+
+describe("App startup", () => {
+  it("reconnects to the session already held in Rust", async () => {
+    // A webview reload must not drop the user back to the picker: the
+    // session lives on the Rust side and survives it.
+    renderApp();
+    expect(await screen.findByRole("heading", { name: "Nodes" })).toBeInTheDocument();
+    expect(screen.queryByText(/Choose a cluster/)).not.toBeInTheDocument();
+  });
+
+  it("shows the picker when there is no session", async () => {
+    currentCluster.mockResolvedValue(null);
+    renderApp();
+    expect(await screen.findByText(/Choose a cluster/)).toBeInTheDocument();
+  });
+
+  it("does not flash the picker before the backend has answered", async () => {
+    // Rendering the picker while the answer is in flight makes every
+    // launch blink, even when a session exists.
+    currentCluster.mockImplementation(() => new Promise(() => {}));
+    renderApp();
+
+    await waitFor(() =>
+      expect(screen.queryByText(/Choose a cluster/)).not.toBeInTheDocument(),
+    );
+  });
+
+  it("falls back to following the system when settings cannot be read", async () => {
+    // No settings file on first run, and no bridge at all in browser
+    // dev. Neither is a reason to refuse to start.
+    getSettings.mockRejectedValue(new Error("no bridge"));
+    renderApp();
+    expect(await screen.findByRole("heading", { name: "Nodes" })).toBeInTheDocument();
+  });
+});
+
+describe("App navigation", () => {
+  it("opens the view the sidebar asks for", async () => {
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+
+    await user.click(screen.getByRole("button", { name: /Helm/ }));
+    await waitFor(() =>
+      expect(api.listHelmReleases).toHaveBeenCalled(),
+    );
+  });
+});
+
+describe("App cluster changes", () => {
+  it("drops every cached list when switching cluster", async () => {
+    // Each cached list belongs to the previous cluster. Invalidating
+    // rather than clearing would let its rows flash on screen under the
+    // new cluster's name.
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+    await waitFor(() => expect(listNodes).toHaveBeenCalled());
+    expect(client.getQueryCache().getAll().length).toBeGreaterThan(0);
+
+    await user.click(screen.getByTitle(/Click to switch cluster/));
+    await user.click(await screen.findByText("orbstack"));
+
+    await waitFor(() => expect(api.connect).toHaveBeenCalledWith("orbstack"));
+  });
+
+  it("clears the cache on disconnect and returns to the picker", async () => {
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+    await waitFor(() =>
+      expect(client.getQueryCache().getAll().length).toBeGreaterThan(0),
+    );
+
+    await user.click(screen.getByRole("button", { name: /Disconnect/i }));
+
+    await waitFor(() => expect(disconnect).toHaveBeenCalledOnce());
+    expect(await screen.findByText(/Choose a cluster/)).toBeInTheDocument();
+    expect(client.getQueryCache().getAll()).toHaveLength(0);
+  });
+
+  it("lets a switch be cancelled back to the live cluster", async () => {
+    // There is a session behind the picker in this case, unlike at
+    // launch, so backing out has to be possible.
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+
+    await user.click(screen.getByTitle(/Click to switch cluster/));
+    expect(await screen.findByText(/Switch to another cluster/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(await screen.findByRole("heading", { name: "Nodes" })).toBeInTheDocument();
+  });
+});
+
+describe("App theme", () => {
+  it("persists a chosen theme", async () => {
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+
+    await user.click(screen.getByRole("radio", { name: "Dark" }));
+    await waitFor(() => expect(setTheme).toHaveBeenCalledWith("dark"));
+    expect(document.documentElement).toHaveClass("dark");
+  });
+
+  it("applies a theme that fails to persist anyway", async () => {
+    // The click should feel instant, and a preference that could not be
+    // written is still the one the user asked for.
+    setTheme.mockRejectedValue(new Error("disk full"));
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+
+    await user.click(screen.getByRole("radio", { name: "Dark" }));
+    await waitFor(() => expect(document.documentElement).toHaveClass("dark"));
+  });
+
+  it("honours a stored preference on launch", async () => {
+    getSettings.mockResolvedValue({ theme: "dark" });
+    renderApp();
+    await waitFor(() => expect(document.documentElement).toHaveClass("dark"));
+  });
+});

--- a/src/components/DataView.test.tsx
+++ b/src/components/DataView.test.tsx
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { DataView } from "./DataView";
+import { api, type DataKey, type ResourceData } from "../lib/api";
+
+// The Data tab is where a Secret is most likely to be leaked by
+// accident, so most of what is asserted here is about what does *not*
+// appear on screen. The Rust side withholds the values; these tests
+// cover the half of the contract the frontend is responsible for —
+// never asking for a value the user did not ask for, and never leaving
+// one on screen after they hid it.
+
+vi.mock("../lib/api", async (original) => {
+  const actual = await original<typeof import("../lib/api")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getSecretData: vi.fn(),
+      getConfigMapData: vi.fn(),
+    },
+  };
+});
+
+const getSecretData = vi.mocked(api.getSecretData);
+const getConfigMapData = vi.mocked(api.getConfigMapData);
+
+function key(
+  name: string,
+  bytes: number,
+  value: string | null = null,
+  binary = false,
+): DataKey {
+  return { key: name, bytes, value, binary };
+}
+
+/// Stands in for the Rust side: returns values only for the keys named
+/// in `reveal`, which is exactly what `secret_data` does.
+function secretBacking(values: Record<string, string>) {
+  return async (
+    _namespace: string,
+    _name: string,
+    reveal: string[] = [],
+  ): Promise<ResourceData> => ({
+    type: "Opaque",
+    redacted: true,
+    keys: Object.entries(values).map(([k, v]) =>
+      key(k, v.length, reveal.includes(k) ? v : null),
+    ),
+  });
+}
+
+function renderData(kind: "config" | "secret") {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <DataView namespace="prod" name="db-credentials" kind={kind} />
+    </QueryClientProvider>,
+  );
+  return userEvent.setup();
+}
+
+beforeEach(() => {
+  getSecretData.mockReset();
+  getConfigMapData.mockReset();
+
+  getSecretData.mockImplementation(
+    secretBacking({ username: "postgres", password: "hunter2" }),
+  );
+  getConfigMapData.mockResolvedValue({
+    type: null,
+    redacted: false,
+    keys: [key("log_level", 5, "debug"), key("timeout", 3, "30s")],
+  });
+});
+
+describe("DataView, on a Secret", () => {
+  it("lists the keys without asking for any value", async () => {
+    renderData("secret");
+    expect(await screen.findByText("password")).toBeInTheDocument();
+    expect(screen.getByText("username")).toBeInTheDocument();
+
+    // The opening request must name no keys. Anything else would fetch
+    // credentials the user never asked to see.
+    expect(getSecretData).toHaveBeenCalledWith("prod", "db-credentials", []);
+    expect(screen.queryByText("hunter2")).not.toBeInTheDocument();
+    expect(screen.queryByText("postgres")).not.toBeInTheDocument();
+  });
+
+  it("says how big a key is without saying what it holds", async () => {
+    // The point of the withheld view: the shape of the Secret answers
+    // most questions, and reading it stays a deliberate act.
+    renderData("secret");
+    expect(await screen.findByText("7 B")).toBeInTheDocument();
+    expect(screen.queryByText("hunter2")).not.toBeInTheDocument();
+  });
+
+  it("reveals only the key that was asked for", async () => {
+    const user = renderData("secret");
+    await screen.findByText("password");
+
+    const rows = screen.getAllByRole("listitem");
+    const passwordRow = rows.find((r) => r.textContent?.includes("password"))!;
+    await user.click(within(passwordRow).getByRole("button", { name: "Reveal" }));
+
+    expect(await screen.findByText("hunter2")).toBeInTheDocument();
+    // The other credential in the same object stays hidden. This is why
+    // `reveal` is a list of names rather than a boolean.
+    expect(screen.queryByText("postgres")).not.toBeInTheDocument();
+    expect(getSecretData).toHaveBeenLastCalledWith("prod", "db-credentials", [
+      "password",
+    ]);
+  });
+
+  it("takes a revealed value back off the screen when hidden", async () => {
+    const user = renderData("secret");
+    await screen.findByText("password");
+
+    const passwordRow = screen
+      .getAllByRole("listitem")
+      .find((r) => r.textContent?.includes("password"))!;
+    await user.click(within(passwordRow).getByRole("button", { name: "Reveal" }));
+    await screen.findByText("hunter2");
+
+    await user.click(
+      within(
+        screen
+          .getAllByRole("listitem")
+          .find((r) => r.textContent?.includes("password"))!,
+      ).getByRole("button", { name: "Hide" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText("hunter2")).not.toBeInTheDocument(),
+    );
+    // And the next request stops asking for it, so a re-fetch does not
+    // quietly bring it back.
+    expect(getSecretData).toHaveBeenLastCalledWith("prod", "db-credentials", []);
+  });
+
+  it("offers no reveal for a binary value", async () => {
+    // A DER-encoded key has nothing legible to show, and a Reveal button
+    // that produces replacement characters reads as a broken app.
+    getSecretData.mockResolvedValue({
+      type: "kubernetes.io/tls",
+      redacted: true,
+      keys: [key("tls.key", 1704, null, true)],
+    });
+
+    renderData("secret");
+    expect(await screen.findByText("binary")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Reveal" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("says that values are held back", async () => {
+    // Without this the tab looks like a Secret with no data in it.
+    renderData("secret");
+    expect(await screen.findByText(/held back/)).toBeInTheDocument();
+  });
+
+  it("shows the Secret's type", async () => {
+    renderData("secret");
+    expect(await screen.findByText("Opaque")).toBeInTheDocument();
+  });
+});
+
+describe("DataView, on a ConfigMap", () => {
+  it("shows every value outright", async () => {
+    // A ConfigMap holds nothing to hide, and making people click Reveal
+    // per key would be friction with no security behind it.
+    renderData("config");
+    expect(await screen.findByText("debug")).toBeInTheDocument();
+    expect(screen.getByText("30s")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Reveal" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not claim anything is held back", async () => {
+    renderData("config");
+    await screen.findByText("debug");
+    expect(screen.queryByText(/held back/)).not.toBeInTheDocument();
+  });
+
+  it("reads a ConfigMap without going near the Secret endpoint", async () => {
+    renderData("config");
+    await screen.findByText("debug");
+    expect(getConfigMapData).toHaveBeenCalledWith("prod", "db-credentials");
+    expect(getSecretData).not.toHaveBeenCalled();
+  });
+});
+
+describe("DataView, when there is nothing to show", () => {
+  it("says so rather than rendering an empty list", async () => {
+    getConfigMapData.mockResolvedValue({
+      type: null,
+      redacted: false,
+      keys: [],
+    });
+    renderData("config");
+    expect(await screen.findByText("No data.")).toBeInTheDocument();
+  });
+
+  it("surfaces a failure instead of looking empty", async () => {
+    // An RBAC denial on Secrets is common and specific; showing "No
+    // data" for it would send the user looking for the wrong problem.
+    getSecretData.mockRejectedValue({
+      kind: "kubernetes",
+      message: 'secrets is forbidden: User "dev" cannot get resource "secrets"',
+    });
+    renderData("secret");
+    expect(await screen.findByText(/forbidden/)).toBeInTheDocument();
+  });
+});

--- a/src/components/EventsTable.test.tsx
+++ b/src/components/EventsTable.test.tsx
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { EventsTable } from "./EventsTable";
+import { api, type EventView } from "../lib/api";
+
+// The Events tab has two modes, and the difference between them is the
+// whole reason it is one component: events *about* one object, and every
+// event *in* a namespace. The second needs to say which object each row
+// is about; the first must not, where it would repeat the page title on
+// every row.
+
+vi.mock("../lib/api", async (original) => {
+  const actual = await original<typeof import("../lib/api")>();
+  return {
+    ...actual,
+    api: { ...actual.api, listEvents: vi.fn(), listNamespaceEvents: vi.fn() },
+  };
+});
+
+const listEvents = vi.mocked(api.listEvents);
+const listNamespaceEvents = vi.mocked(api.listNamespaceEvents);
+
+function event(overrides: Partial<EventView> = {}): EventView {
+  return {
+    type: "Warning",
+    reason: "BackOff",
+    message: "Back-off restarting failed container",
+    count: 12,
+    age: "3m",
+    source: "kubelet",
+    object: "Pod/coredns-abc",
+    ...overrides,
+  };
+}
+
+function renderEvents(props: { namespace: string; name?: string }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <EventsTable {...props} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  listEvents.mockReset();
+  listNamespaceEvents.mockReset();
+  listEvents.mockResolvedValue([event()]);
+  listNamespaceEvents.mockResolvedValue([event()]);
+});
+
+describe("EventsTable", () => {
+  it("filters to one object when given a name", async () => {
+    renderEvents({ namespace: "kube-system", name: "coredns-abc" });
+    expect(await screen.findByText(/Back-off/)).toBeInTheDocument();
+
+    expect(listEvents).toHaveBeenCalledWith("kube-system", "coredns-abc");
+    expect(listNamespaceEvents).not.toHaveBeenCalled();
+  });
+
+  it("omits the subject column on one object's own events", async () => {
+    // It would repeat the page title on every row.
+    renderEvents({ namespace: "kube-system", name: "coredns-abc" });
+    await screen.findByText(/Back-off/);
+    expect(
+      screen.queryByRole("columnheader", { name: "Subject" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows every event in the namespace when given no name", async () => {
+    // A namespace object almost never has events of its own. What an
+    // operator wants from a namespace is what is going wrong inside it.
+    renderEvents({ namespace: "kube-system" });
+    expect(await screen.findByText(/Back-off/)).toBeInTheDocument();
+
+    expect(listNamespaceEvents).toHaveBeenCalledWith("kube-system");
+    expect(listEvents).not.toHaveBeenCalled();
+  });
+
+  it("names the subject in the namespace-wide view", async () => {
+    // With a hundred events from a hundred pods, which object it is
+    // about is the first thing you read.
+    renderEvents({ namespace: "kube-system" });
+    await screen.findByText(/Back-off/);
+    expect(
+      screen.getByRole("columnheader", { name: "Subject" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Pod/coredns-abc")).toBeInTheDocument();
+  });
+
+  it("fills in a count for an event that fired once", async () => {
+    // The API omits `count` for a single occurrence. An empty cell reads
+    // as missing data rather than as "once".
+    listEvents.mockResolvedValue([event({ count: null })]);
+    renderEvents({ namespace: "kube-system", name: "coredns-abc" });
+    await screen.findByText(/Back-off/);
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  it("renders an em dash for the fields an event may omit", async () => {
+    listEvents.mockResolvedValue([
+      event({ reason: null, message: null, age: null }),
+    ]);
+    renderEvents({ namespace: "kube-system", name: "coredns-abc" });
+    expect((await screen.findAllByText("—")).length).toBeGreaterThan(0);
+  });
+
+  it("explains an empty list rather than looking broken", async () => {
+    // Events expire after about an hour, so empty is a normal result and
+    // saying why saves the user looking for a bug.
+    listEvents.mockResolvedValue([]);
+    renderEvents({ namespace: "kube-system", name: "coredns-abc" });
+    expect(await screen.findByText(/discards them/)).toBeInTheDocument();
+  });
+
+  it("surfaces a failure to list", async () => {
+    listEvents.mockRejectedValue({
+      kind: "kubernetes",
+      message: 'events is forbidden: User "dev" cannot list resource "events"',
+    });
+    renderEvents({ namespace: "kube-system", name: "coredns-abc" });
+    expect(await screen.findByText(/forbidden/)).toBeInTheDocument();
+  });
+});

--- a/src/components/LogViewer.test.tsx
+++ b/src/components/LogViewer.test.tsx
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LogViewer } from "./LogViewer";
+import { api, type ContainerView, type LogEvent } from "../lib/api";
+
+// The log viewer is the only component holding a long-lived resource: a
+// followed stream is an open HTTP connection to the API server. Most of
+// what is asserted here is about closing them — a leak per view is
+// invisible until a session has a hundred of them.
+
+vi.mock("../lib/api", async (original) => {
+  const actual = await original<typeof import("../lib/api")>();
+  return {
+    ...actual,
+    // Tauri's own Channel reaches into `window.__TAURI_INTERNALS__`,
+    // which only exists inside the webview. The component treats a
+    // channel as a thing with an `onmessage`, so that is all the
+    // stand-in needs to be. Declared in here because vi.mock's factory
+    // is hoisted above anything defined at the top level of the file.
+    Channel: class {
+      onmessage?: (event: LogEvent) => void;
+    },
+    api: { ...actual.api, startPodLogs: vi.fn(), stopPodLogs: vi.fn() },
+  };
+});
+
+const startPodLogs = vi.mocked(api.startPodLogs);
+const stopPodLogs = vi.mocked(api.stopPodLogs);
+
+/// Captures the channel each stream was opened with, so a test can push
+/// lines down it the way the Rust side would.
+let channels: { onmessage?: (e: LogEvent) => void }[] = [];
+
+function container(name: string): ContainerView {
+  return {
+    name,
+    image: `${name}:1.0`,
+    ready: true,
+    restarts: 0,
+    state: "Running",
+    lastState: null,
+  };
+}
+
+function renderViewer(containers = [container("app")]) {
+  render(
+    <LogViewer namespace="kube-system" pod="coredns-abc" containers={containers} />,
+  );
+  return userEvent.setup();
+}
+
+/// Pushes an event down the most recently opened channel, the way the
+/// Rust side does. Wrapped in `act` because it lands as a state update
+/// arriving from outside React.
+function emit(event: LogEvent) {
+  act(() => {
+    channels[channels.length - 1]?.onmessage?.(event);
+  });
+}
+
+beforeEach(() => {
+  channels = [];
+  startPodLogs.mockReset();
+  stopPodLogs.mockReset();
+
+  let nextId = 1;
+  startPodLogs.mockImplementation(async (_options, channel) => {
+    channels.push(channel as unknown as { onmessage?: (e: LogEvent) => void });
+    return nextId++;
+  });
+  stopPodLogs.mockResolvedValue(true);
+});
+
+describe("LogViewer", () => {
+  it("opens a stream for the pod's container", async () => {
+    renderViewer();
+    await waitFor(() => expect(startPodLogs).toHaveBeenCalled());
+
+    const [options] = startPodLogs.mock.calls[0];
+    expect(options.namespace).toBe("kube-system");
+    expect(options.pod).toBe("coredns-abc");
+    expect(options.container).toBe("app");
+    // Without a bound, attaching to a long-running pod dumps its entire
+    // retained buffer into the DOM.
+    expect(options.tailLines).toBe(500);
+  });
+
+  it("renders the lines the stream pushes", async () => {
+    renderViewer();
+    await waitFor(() => expect(startPodLogs).toHaveBeenCalled());
+
+    emit({ kind: "line", text: "listening on :8080" });
+    emit({ kind: "line", text: "ready" });
+
+    expect(await screen.findByText(/listening on :8080/)).toBeInTheDocument();
+    expect(screen.getByText(/ready/)).toBeInTheDocument();
+  });
+
+  it("says when a stream has ended", async () => {
+    // A view that simply stops producing lines is indistinguishable from
+    // a quiet pod, which is why the Rust side sends an explicit Ended.
+    renderViewer();
+    await waitFor(() => expect(startPodLogs).toHaveBeenCalled());
+
+    emit({ kind: "ended" });
+    expect(await screen.findByText("ended")).toBeInTheDocument();
+  });
+
+  it("surfaces a stream failure rather than going quiet", async () => {
+    renderViewer();
+    await waitFor(() => expect(startPodLogs).toHaveBeenCalled());
+
+    emit({ kind: "failed", message: "container app is not running" });
+    expect(await screen.findByText(/is not running/)).toBeInTheDocument();
+  });
+
+  it("surfaces a failure to open the stream at all", async () => {
+    // An RBAC denial or a bad container name fails here rather than on
+    // the channel, and has to reach the screen the same way.
+    startPodLogs.mockRejectedValue({
+      kind: "kubernetes",
+      message: 'pods/log is forbidden: User "dev" cannot get',
+    });
+
+    renderViewer();
+    expect(await screen.findByText(/forbidden/)).toBeInTheDocument();
+  });
+
+  it("stops the stream when the view goes away", async () => {
+    // The leak that matters: a followed stream holds a connection open,
+    // and closing the tab must close it.
+    const { unmount } = render(
+      <LogViewer
+        namespace="kube-system"
+        pod="coredns-abc"
+        containers={[container("app")]}
+      />,
+    );
+    await waitFor(() => expect(startPodLogs).toHaveBeenCalled());
+
+    unmount();
+    await waitFor(() => expect(stopPodLogs).toHaveBeenCalledWith(1));
+  });
+
+  it("stops the old stream before it starts a new one", async () => {
+    // Toggling an option restarts the stream. Without the teardown each
+    // toggle would leave the previous one running.
+    const user = renderViewer();
+    await waitFor(() => expect(startPodLogs).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole("checkbox", { name: /Timestamps/ }));
+
+    await waitFor(() => expect(startPodLogs).toHaveBeenCalledTimes(2));
+    expect(stopPodLogs).toHaveBeenCalledWith(1);
+    expect(startPodLogs.mock.calls[1][0].timestamps).toBe(true);
+  });
+
+  it("reads the previous container instance when asked", async () => {
+    // The only way to see why a CrashLoopBackOff pod died, so the flag
+    // has to reach the command rather than only the checkbox.
+    const user = renderViewer();
+    await waitFor(() => expect(startPodLogs).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole("checkbox", { name: /Previous/ }));
+    await waitFor(() => expect(startPodLogs).toHaveBeenCalledTimes(2));
+    expect(startPodLogs.mock.calls[1][0].previous).toBe(true);
+  });
+
+  it("clears the previous container's lines when switching", async () => {
+    // Otherwise one container's output appears under another's name,
+    // which is worse than showing nothing.
+    const user = renderViewer([container("app"), container("sidecar")]);
+    await waitFor(() => expect(startPodLogs).toHaveBeenCalledTimes(1));
+
+    emit({ kind: "line", text: "from-app" });
+    await screen.findByText(/from-app/);
+
+    await user.selectOptions(screen.getByRole("combobox"), "sidecar");
+    await waitFor(() => expect(startPodLogs).toHaveBeenCalledTimes(2));
+
+    expect(screen.queryByText(/from-app/)).not.toBeInTheDocument();
+    expect(startPodLogs.mock.calls[1][0].container).toBe("sidecar");
+  });
+
+  it("offers no container picker for a single-container pod", () => {
+    // The overwhelmingly common case; a select with one option is noise.
+    renderViewer();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("says so when a container produced nothing", async () => {
+    renderViewer();
+    await waitFor(() => expect(startPodLogs).toHaveBeenCalled());
+
+    emit({ kind: "ended" });
+    expect(await screen.findByText("No output.")).toBeInTheDocument();
+  });
+
+  it("follows by default", async () => {
+    // Opening logs on a running pod and watching nothing arrive is a
+    // confusing first impression.
+    renderViewer();
+    await waitFor(() => expect(startPodLogs).toHaveBeenCalled());
+    expect(startPodLogs.mock.calls[0][0].follow).toBe(true);
+    expect(screen.getByRole("checkbox", { name: /Follow/ })).toBeChecked();
+  });
+});

--- a/src/components/ResourceTable.test.tsx
+++ b/src/components/ResourceTable.test.tsx
@@ -1,0 +1,217 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ResourceTable } from "./ResourceTable";
+import { Table, type Column } from "./Table";
+
+// Every resource view in the app renders through these two. What is
+// asserted here is the behaviour a view inherits for free and would
+// otherwise have to be re-tested per page: search, pagination, the
+// empty states, and keyboard access to a row.
+
+interface Row {
+  name: string;
+  phase: string;
+}
+
+const COLUMNS: Column<Row>[] = [
+  { key: "name", header: "Name", render: (r) => r.name },
+  { key: "phase", header: "Phase", render: (r) => r.phase, mono: true },
+];
+
+function rows(count: number, phase = "Running"): Row[] {
+  return Array.from({ length: count }, (_, i) => ({
+    name: `pod-${String(i).padStart(3, "0")}`,
+    phase,
+  }));
+}
+
+function renderTable(props: Partial<Parameters<typeof ResourceTable<Row>>[0]> = {}) {
+  render(
+    <ResourceTable<Row>
+      columns={COLUMNS}
+      rows={rows(3)}
+      rowKey={(r) => r.name}
+      searchText={(r) => `${r.name} ${r.phase}`}
+      isLoading={false}
+      {...props}
+    />,
+  );
+  return userEvent.setup();
+}
+
+describe("ResourceTable search", () => {
+  it("narrows on every term rather than widening", async () => {
+    // "kube running" should mean both, not either. An OR here would
+    // make each extra word return more rows, which is the opposite of
+    // what typing more words is for.
+    const user = renderTable({
+      rows: [
+        { name: "kube-dns", phase: "Running" },
+        { name: "kube-proxy", phase: "Pending" },
+        { name: "app", phase: "Running" },
+      ],
+    });
+
+    await user.type(screen.getByPlaceholderText("Search…"), "kube running");
+    expect(screen.getByText("kube-dns")).toBeInTheDocument();
+    expect(screen.queryByText("kube-proxy")).not.toBeInTheDocument();
+    expect(screen.queryByText("app")).not.toBeInTheDocument();
+  });
+
+  it("matches regardless of case", async () => {
+    const user = renderTable({ rows: [{ name: "Kube-DNS", phase: "Running" }] });
+    await user.type(screen.getByPlaceholderText("Search…"), "kube-dns");
+    expect(screen.getByText("Kube-DNS")).toBeInTheDocument();
+  });
+
+  it("reports how much of the set is showing", async () => {
+    const user = renderTable({
+      rows: [
+        { name: "kube-dns", phase: "Running" },
+        { name: "app", phase: "Running" },
+      ],
+    });
+    expect(screen.getByText("2 items")).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText("Search…"), "kube");
+    expect(screen.getByText("1 of 2")).toBeInTheDocument();
+  });
+
+  it("names the query when nothing matches", async () => {
+    // "Nothing to show" would read as an empty cluster rather than as a
+    // filter the user can clear.
+    const user = renderTable();
+    await user.type(screen.getByPlaceholderText("Search…"), "zzz");
+    expect(screen.getByText(/Nothing matches/)).toBeInTheDocument();
+    expect(screen.getByText(/zzz/)).toBeInTheDocument();
+  });
+
+  it("searches only what the row displays", async () => {
+    // searchText is explicit rather than a stringified object, so a
+    // match always corresponds to something the user can see.
+    const user = renderTable({ searchText: (r: Row) => r.name });
+    await user.type(screen.getByPlaceholderText("Search…"), "Running");
+    expect(screen.getByText(/Nothing matches/)).toBeInTheDocument();
+  });
+});
+
+describe("ResourceTable pagination", () => {
+  it("stays on one page for a set that fits", () => {
+    renderTable({ rows: rows(50) });
+    expect(screen.queryByText("1 / 2")).not.toBeInTheDocument();
+  });
+
+  it("pages a set that does not fit", async () => {
+    const user = renderTable({ rows: rows(120) });
+    expect(screen.getByText("1 / 3")).toBeInTheDocument();
+    expect(screen.getByText("pod-000")).toBeInTheDocument();
+    expect(screen.queryByText("pod-050")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "›" }));
+    expect(screen.getByText("pod-050")).toBeInTheDocument();
+    expect(screen.queryByText("pod-000")).not.toBeInTheDocument();
+    expect(screen.getByText("51–100 of 120")).toBeInTheDocument();
+  });
+
+  it("cannot page past either end", async () => {
+    const user = renderTable({ rows: rows(120) });
+    expect(screen.getByRole("button", { name: "‹" })).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: "›" }));
+    await user.click(screen.getByRole("button", { name: "›" }));
+    expect(screen.getByText("3 / 3")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "›" })).toBeDisabled();
+  });
+
+  it("returns to the first page when a search shrinks the set", async () => {
+    // Otherwise the user searches from page 3 and gets an empty table
+    // sitting under a non-zero result count.
+    const user = renderTable({ rows: rows(120) });
+    await user.click(screen.getByRole("button", { name: "›" }));
+    expect(screen.getByText("pod-050")).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText("Search…"), "pod-00");
+    expect(screen.getByText("pod-000")).toBeInTheDocument();
+  });
+});
+
+describe("ResourceTable states", () => {
+  it("shows placeholders rather than an empty table while loading", () => {
+    renderTable({ isLoading: true, rows: undefined });
+    // No "0 items" count, which would claim the cluster is empty before
+    // anything has been read.
+    expect(screen.queryByText("0 items")).not.toBeInTheDocument();
+  });
+
+  it("uses the caller's wording for an empty set", () => {
+    renderTable({
+      rows: [],
+      empty: "No events. Kubernetes discards them after about an hour.",
+    });
+    expect(screen.getByText(/discards them/)).toBeInTheDocument();
+  });
+
+  it("renders a toolbar beside the search box", () => {
+    renderTable({ toolbar: <button>Wide</button> });
+    expect(screen.getByRole("button", { name: "Wide" })).toBeInTheDocument();
+  });
+});
+
+describe("Table rows", () => {
+  it("opens a row on click when it is clickable", async () => {
+    const onRowClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Table
+        columns={COLUMNS}
+        rows={rows(1)}
+        rowKey={(r) => r.name}
+        onRowClick={onRowClick}
+      />,
+    );
+
+    await user.click(screen.getByText("pod-000"));
+    expect(onRowClick).toHaveBeenCalledWith({ name: "pod-000", phase: "Running" });
+  });
+
+  it("opens a row from the keyboard", async () => {
+    // A resource list that can only be driven with a mouse is a list
+    // half the people using a terminal client cannot use.
+    const onRowClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Table
+        columns={COLUMNS}
+        rows={rows(1)}
+        rowKey={(r) => r.name}
+        onRowClick={onRowClick}
+      />,
+    );
+
+    await user.tab();
+    await user.keyboard("{Enter}");
+    expect(onRowClick).toHaveBeenCalledOnce();
+
+    await user.keyboard(" ");
+    expect(onRowClick).toHaveBeenCalledTimes(2);
+  });
+
+  it("is not focusable when a row does nothing", async () => {
+    // A tab stop that goes nowhere is worse than no tab stop.
+    const user = userEvent.setup();
+    render(<Table columns={COLUMNS} rows={rows(1)} rowKey={(r) => r.name} />);
+
+    const row = screen.getByText("pod-000").closest("tr")!;
+    expect(row).not.toHaveAttribute("tabindex");
+    await user.tab();
+    expect(row).not.toHaveFocus();
+  });
+
+  it("renders the headers the columns declare", () => {
+    render(<Table columns={COLUMNS} rows={rows(1)} rowKey={(r) => r.name} />);
+    const header = screen.getAllByRole("row")[0];
+    expect(within(header).getByText("Name")).toBeInTheDocument();
+    expect(within(header).getByText("Phase")).toBeInTheDocument();
+  });
+});

--- a/src/components/primitives.test.tsx
+++ b/src/components/primitives.test.tsx
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Chip, ChipList, eventTone } from "./Chip";
+import { StatusDot, phaseTone } from "./StatusDot";
+import { Select } from "./Select";
+import { Panel, ErrorStrip } from "./Panel";
+import { YamlView } from "./YamlView";
+
+// The small shared pieces. Most of what is worth pinning here is the
+// mapping from a Kubernetes value to a colour, because those are the
+// judgements a reader trusts without checking.
+
+describe("phaseTone", () => {
+  it("does not colour a finished pod as healthy", () => {
+    // A Succeeded Job pod is finished, not healthy. Green would say a
+    // completed batch job is still doing its work.
+    expect(phaseTone("Succeeded")).toBe("unknown");
+    expect(phaseTone("Running")).toBe("ok");
+    expect(phaseTone("Pending")).toBe("warn");
+    expect(phaseTone("Failed")).toBe("danger");
+  });
+
+  it("leaves a phase it does not know about uncoloured", () => {
+    // The API can grow phases. Guessing would eventually colour a real
+    // problem green.
+    expect(phaseTone("Terminating")).toBe("unknown");
+    expect(phaseTone("")).toBe("unknown");
+  });
+});
+
+describe("eventTone", () => {
+  it("maps the closed set Kubernetes actually uses", () => {
+    expect(eventTone("Normal")).toBe("ok");
+    expect(eventTone("Warning")).toBe("warn");
+    expect(eventTone("Error")).toBe("danger");
+  });
+
+  it("stays neutral for anything else", () => {
+    expect(eventTone("Informational")).toBe("neutral");
+  });
+});
+
+describe("StatusDot", () => {
+  it("always shows the label beside the dot", () => {
+    // Colour alone fails for anyone with a colour-vision deficiency, so
+    // the dot never replaces the word.
+    render(<StatusDot tone="danger" label="Failed" />);
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+  });
+});
+
+describe("ChipList", () => {
+  it("renders one chip per value", () => {
+    // A comma-separated string reads as one blob; chips read as N things.
+    render(<ChipList values={["control-plane", "etcd", "master"]} />);
+    expect(screen.getByText("control-plane")).toBeInTheDocument();
+    expect(screen.getByText("etcd")).toBeInTheDocument();
+    expect(screen.getByText("master")).toBeInTheDocument();
+  });
+
+  it("renders an em dash rather than nothing when empty", () => {
+    // An empty cell reads as a rendering failure.
+    render(<ChipList values={[]} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("carries a title through for a truncated value", () => {
+    render(<Chip title="the full value">short</Chip>);
+    expect(screen.getByTitle("the full value")).toBeInTheDocument();
+  });
+});
+
+describe("Select", () => {
+  it("reports the chosen value", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Select value="app" onChange={onChange}>
+        <option value="app">app</option>
+        <option value="sidecar">sidecar</option>
+      </Select>,
+    );
+
+    await user.selectOptions(screen.getByRole("combobox"), "sidecar");
+    expect(onChange).toHaveBeenCalledWith("sidecar");
+  });
+});
+
+describe("ErrorStrip", () => {
+  it("announces itself to a screen reader", () => {
+    render(<ErrorStrip error={{ kind: "kubernetes", message: "boom" }} />);
+    expect(screen.getByRole("alert")).toHaveTextContent("boom");
+  });
+
+  it("renders a plain Error as its message", () => {
+    render(<ErrorStrip error={new Error("network unreachable")} />);
+    expect(screen.getByRole("alert")).toHaveTextContent("network unreachable");
+  });
+});
+
+describe("Panel", () => {
+  it("shows its title and body", () => {
+    render(
+      <Panel title="Pods" subtitle="kube-system">
+        <p>body</p>
+      </Panel>,
+    );
+    expect(screen.getByRole("heading", { name: "Pods" })).toBeInTheDocument();
+    expect(screen.getByText("kube-system")).toBeInTheDocument();
+    expect(screen.getByText("body")).toBeInTheDocument();
+  });
+
+  it("offers Refresh only when there is something to refresh", async () => {
+    const onRefresh = vi.fn();
+    const user = userEvent.setup();
+    const { rerender } = render(<Panel title="Pods">body</Panel>);
+    expect(
+      screen.queryByRole("button", { name: "Refresh" }),
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <Panel title="Pods" onRefresh={onRefresh}>
+        body
+      </Panel>,
+    );
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("shows a quiet indicator during a refetch rather than blanking", () => {
+    // Replacing a populated table with grey bars every few seconds is
+    // worse than a slightly stale number.
+    render(
+      <Panel title="Pods" isFetching>
+        <p>existing rows</p>
+      </Panel>,
+    );
+    expect(screen.getByText("refreshing")).toBeInTheDocument();
+    expect(screen.getByText("existing rows")).toBeInTheDocument();
+  });
+
+  it("surfaces an error above the body", () => {
+    render(
+      <Panel title="Pods" error={{ kind: "not_connected", message: "no cluster" }}>
+        body
+      </Panel>,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent("no cluster");
+  });
+});
+
+describe("YamlView", () => {
+  it("numbers every line", () => {
+    render(<YamlView source={"apiVersion: v1\nkind: Pod\nmetadata:\n"} />);
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("copies the source rather than what is rendered", async () => {
+    // The pane interleaves line numbers with the text. Copying that
+    // would produce YAML nobody can apply.
+    const source = "apiVersion: v1\nkind: Pod\n";
+    const user = userEvent.setup();
+
+    // After `setup()`, which installs a clipboard stub of its own, and
+    // via defineProperty because jsdom exposes it as a getter.
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(<YamlView source={source} />);
+
+    await user.click(screen.getByRole("button", { name: "Copy" }));
+    expect(writeText).toHaveBeenCalledWith(source);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument(),
+    );
+  });
+});

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,218 @@
+// Vite inlines these at build time, so the drift check below needs no
+// filesystem access and no Node type definitions.
+import libRs from "../../src-tauri/src/lib.rs?raw";
+import apiTs from "./api.ts?raw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { api, errorMessage, isApiError, isConflict } from "./api";
+
+// Two things are covered here.
+//
+// The first is the command names. They are strings on this side and
+// function names on the Rust side, and nothing in either compiler
+// connects them — a rename in lib.rs leaves this file calling a command
+// that no longer exists, and the failure shows up at runtime as an
+// unhandled rejection with no obvious cause. The last test in this file
+// reads lib.rs and compares the two sets directly.
+//
+// The second is argument naming. Tauri matches arguments by name, so
+// `{ namespace }` and `{ ns }` are not interchangeable, and getting one
+// wrong produces a command that runs with a null it did not expect.
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+  Channel: class {},
+}));
+
+const invoked = vi.mocked(invoke);
+
+beforeEach(() => {
+  invoked.mockReset();
+  invoked.mockResolvedValue(undefined);
+});
+
+/// The command name and payload of the last invoke.
+function lastCall() {
+  const calls = invoked.mock.calls;
+  const [command, args] = calls[calls.length - 1];
+  return { command, args };
+}
+
+describe("api command names and arguments", () => {
+  it("sends an absent namespace as null rather than omitting it", async () => {
+    // "All namespaces" and "the namespace named undefined" are different
+    // requests. Tauri would deserialise a missing key as an error on a
+    // non-Option parameter, and the cluster-wide listing is the default
+    // view — so this is the path most likely to be exercised.
+    await api.listPods();
+    expect(lastCall()).toEqual({
+      command: "list_pods",
+      args: { namespace: null },
+    });
+
+    await api.listPods("kube-system");
+    expect(lastCall().args).toEqual({ namespace: "kube-system" });
+  });
+
+  it("names every argument the way the Rust side declares it", async () => {
+    const resource = { group: "apps", version: "v1", kind: "Deployment" };
+
+    await api.connect("orbstack");
+    expect(lastCall()).toEqual({ command: "connect", args: { context: "orbstack" } });
+
+    await api.getPod("prod", "web");
+    expect(lastCall()).toEqual({
+      command: "get_pod",
+      args: { namespace: "prod", name: "web" },
+    });
+
+    await api.getNode("worker-1");
+    expect(lastCall()).toEqual({ command: "get_node", args: { name: "worker-1" } });
+
+    await api.listPodsOnNode("worker-1");
+    expect(lastCall()).toEqual({
+      command: "list_pods_on_node",
+      args: { node: "worker-1" },
+    });
+
+    await api.listEvents("prod", "web");
+    expect(lastCall()).toEqual({
+      command: "list_events",
+      args: { namespace: "prod", name: "web" },
+    });
+
+    await api.getObject(resource, "prod", "web");
+    expect(lastCall()).toEqual({
+      command: "get_object",
+      args: { resource, namespace: "prod", name: "web" },
+    });
+
+    await api.listTable(resource);
+    expect(lastCall()).toEqual({
+      command: "list_table",
+      args: { resource, namespace: null },
+    });
+
+    await api.getHelmRelease("monitoring", "prom");
+    expect(lastCall()).toEqual({
+      command: "get_helm_release",
+      args: { namespace: "monitoring", name: "prom" },
+    });
+
+    await api.stopPodLogs(7);
+    expect(lastCall()).toEqual({ command: "stop_pod_logs", args: { id: 7 } });
+
+    await api.setTheme("dark");
+    expect(lastCall()).toEqual({ command: "set_theme", args: { theme: "dark" } });
+  });
+
+  it("asks for no Secret values by default", async () => {
+    // The default has to be the safe one. A caller that forgets the
+    // third argument must not get every credential in the object.
+    await api.getSecretData("prod", "db-credentials");
+    expect(lastCall()).toEqual({
+      command: "get_secret_data",
+      args: { namespace: "prod", name: "db-credentials", reveal: [] },
+    });
+  });
+
+  it("sends the edit target alongside the text", async () => {
+    // The target is what makes a rename detectable: without it the Rust
+    // side would have to trust whatever identity the edited text claims.
+    const target = {
+      apiVersion: "v1",
+      kind: "ConfigMap",
+      namespace: "prod",
+      name: "settings",
+    };
+    await api.applyYaml(target, "kind: ConfigMap\n");
+    expect(lastCall()).toEqual({
+      command: "apply_yaml",
+      args: { target, yaml: "kind: ConfigMap\n" },
+    });
+  });
+});
+
+describe("error handling across the IPC boundary", () => {
+  it("recognises a conflict by its kind, not its wording", () => {
+    // The message is written for a human and will be reworded. The kind
+    // is the contract, and it is what gates the editor's reload path.
+    expect(isConflict({ kind: "conflict", message: "anything at all" })).toBe(true);
+    expect(isConflict({ kind: "kubernetes", message: "409 Conflict" })).toBe(
+      false,
+    );
+    expect(isConflict("conflict")).toBe(false);
+    expect(isConflict(null)).toBe(false);
+    expect(isConflict(undefined)).toBe(false);
+  });
+
+  it("gets a message out of anything that can be thrown", () => {
+    // Tauri rejects with the serialised error object, but a panic on the
+    // Rust side arrives as a bare string, and a transport failure as an
+    // Error. All three end up in front of the user.
+    expect(errorMessage({ kind: "kubernetes", message: "forbidden" })).toBe(
+      "forbidden",
+    );
+    expect(errorMessage("panicked at 'unwrap on None'")).toBe(
+      "panicked at 'unwrap on None'",
+    );
+    expect(errorMessage(new Error("network unreachable"))).toBe(
+      "network unreachable",
+    );
+    // Never an empty string or "undefined", which read as a broken app
+    // rather than as a failure.
+    expect(errorMessage(null)).toBe("unexpected error");
+    expect(errorMessage(42)).toBe("unexpected error");
+  });
+
+  it("does not mistake an arbitrary object for an api error", () => {
+    expect(isApiError({ kind: "conflict", message: "x" })).toBe(true);
+    expect(isApiError({ kind: "conflict" })).toBe(false);
+    expect(isApiError([])).toBe(false);
+  });
+});
+
+
+describe("the command list agrees with the Rust side", () => {
+  /// The commands `lib.rs` registers, and the ones `api.ts` calls.
+  function commandSets() {
+    const handler = libRs.match(/generate_handler!\[([\s\S]*?)\]/);
+    expect(handler, "generate_handler! not found in lib.rs").not.toBeNull();
+
+    const registered = handler![1]
+      .split(",")
+      .map((name: string) => name.trim())
+      .filter(Boolean);
+
+    // Every `invoke<T>("command_name"` in the wrapper file.
+    const called = [
+      ...apiTs.matchAll(/invoke<[^>]*>\(\s*"([a-z_]+)"/g),
+    ].map((m: RegExpMatchArray) => m[1]);
+
+    return { registered, called };
+  }
+
+  it("invokes only commands lib.rs actually registers", () => {
+    // The check this file exists for. Nothing else connects these two
+    // sets: a command renamed in Rust leaves the string here pointing at
+    // nothing, and the app fails at runtime rather than at build time.
+    const { registered, called } = commandSets();
+    expect(called.length).toBeGreaterThan(20);
+
+    const known = new Set(registered);
+    const missing = called.filter((c) => !known.has(c));
+    expect(missing, `not registered in lib.rs: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("leaves no registered command unreachable from the frontend", () => {
+    // The other direction. A command nobody calls is either dead code or
+    // a feature that was wired up on one side only.
+    const { registered, called } = commandSets();
+    const used = new Set(called);
+
+    const unused = registered.filter((c) => !used.has(c));
+    expect(unused, `registered but never called: ${unused.join(", ")}`).toEqual(
+      [],
+    );
+  });
+});

--- a/src/lib/window.test.ts
+++ b/src/lib/window.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MouseEvent } from "react";
+import { dragRegionProps } from "./window";
+
+// The window has no native title bar, so these handlers are the only
+// thing making it movable. What is worth pinning is where dragging must
+// *not* happen: a mousedown on a button has to press the button, and a
+// right-click has to stay a right-click.
+
+const startDragging = vi.fn();
+const toggleMaximize = vi.fn();
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ startDragging, toggleMaximize }),
+}));
+
+/// A mouse event carrying only what these handlers read.
+function mouse(target: HTMLElement, button = 0) {
+  return { button, target } as unknown as MouseEvent<HTMLElement>;
+}
+
+/// The handlers import Tauri lazily, so the call lands a microtask later.
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function element(html: string): HTMLElement {
+  document.body.innerHTML = `<header>${html}</header>`;
+  return document.body.querySelector("header")!;
+}
+
+beforeEach(() => {
+  startDragging.mockReset();
+  toggleMaximize.mockReset();
+});
+
+describe("dragRegionProps", () => {
+  it("drags the window from an empty part of the header", async () => {
+    dragRegionProps.onMouseDown(mouse(element("<span>Pods</span>")));
+    await settle();
+    expect(startDragging).toHaveBeenCalledOnce();
+  });
+
+  it("does not drag from a control inside the header", async () => {
+    // The header holds Refresh, the namespace picker and the theme
+    // switch. Picking the window up instead of pressing them would make
+    // every one of them unusable.
+    const header = element("<button>Refresh</button>");
+    const button = header.querySelector("button")!;
+
+    dragRegionProps.onMouseDown(mouse(button));
+    await settle();
+    expect(startDragging).not.toHaveBeenCalled();
+  });
+
+  it("does not drag from a control nested inside a control", async () => {
+    // `closest` rather than a direct check, because the click lands on
+    // whatever is innermost — the label inside the button.
+    const header = element("<button><span>Refresh</span></button>");
+    const label = header.querySelector("span")!;
+
+    dragRegionProps.onMouseDown(mouse(label));
+    await settle();
+    expect(startDragging).not.toHaveBeenCalled();
+  });
+
+  it("respects an explicit opt-out", async () => {
+    const header = element('<div class="no-drag"><span>x</span></div>');
+    dragRegionProps.onMouseDown(mouse(header.querySelector("span")!));
+    await settle();
+    expect(startDragging).not.toHaveBeenCalled();
+  });
+
+  it("ignores anything but the left button", async () => {
+    // A right-click is a context menu, and a middle-click drag is not a
+    // gesture anyone means.
+    const header = element("<span>Pods</span>");
+    dragRegionProps.onMouseDown(mouse(header, 2));
+    dragRegionProps.onMouseDown(mouse(header, 1));
+    await settle();
+    expect(startDragging).not.toHaveBeenCalled();
+  });
+
+  it("zooms on a double-click of the title bar", async () => {
+    // Muscle memory on macOS.
+    dragRegionProps.onDoubleClick(mouse(element("<span>Pods</span>")));
+    await settle();
+    expect(toggleMaximize).toHaveBeenCalledOnce();
+  });
+
+  it("does not zoom on a double-click of a control", async () => {
+    const header = element("<button>Refresh</button>");
+    dragRegionProps.onDoubleClick(mouse(header.querySelector("button")!));
+    await settle();
+    expect(toggleMaximize).not.toHaveBeenCalled();
+  });
+
+  it("swallows a failure rather than taking the UI down", async () => {
+    // In browser dev there is no Tauri window behind the bridge. Failing
+    // to drag is a small bug; an unhandled rejection on every mousedown
+    // in the header is a much larger one.
+    startDragging.mockRejectedValue(new Error("no window"));
+    dragRegionProps.onMouseDown(mouse(element("<span>Pods</span>")));
+    await settle();
+    expect(startDragging).toHaveBeenCalledOnce();
+  });
+});

--- a/src/pages/ContextPicker.test.tsx
+++ b/src/pages/ContextPicker.test.tsx
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ContextPicker } from "./ContextPicker";
+import { api, type ContextInfo } from "../lib/api";
+
+// The launch screen. Listing contexts is offline by design, so this
+// renders even when every cluster in the file is unreachable — which
+// means connecting is where failure becomes visible, and it has to
+// report per attempt rather than blanking the list.
+
+vi.mock("../lib/api", async (original) => {
+  const actual = await original<typeof import("../lib/api")>();
+  return {
+    ...actual,
+    api: { ...actual.api, listContexts: vi.fn(), connect: vi.fn() },
+  };
+});
+
+vi.mock("../lib/window", () => ({
+  dragRegionProps: {},
+}));
+
+const listContexts = vi.mocked(api.listContexts);
+const connect = vi.mocked(api.connect);
+
+function context(name: string, overrides: Partial<ContextInfo> = {}): ContextInfo {
+  return {
+    name,
+    cluster: `${name}-cluster`,
+    user: `${name}-user`,
+    namespace: null,
+    isCurrent: false,
+    ...overrides,
+  };
+}
+
+function renderPicker(props: Partial<Parameters<typeof ContextPicker>[0]> = {}) {
+  const onConnected = vi.fn();
+  render(<ContextPicker onConnected={onConnected} {...props} />);
+  return { user: userEvent.setup(), onConnected };
+}
+
+beforeEach(() => {
+  listContexts.mockReset();
+  connect.mockReset();
+
+  listContexts.mockResolvedValue([
+    context("prod", { namespace: "payments" }),
+    context("staging", { isCurrent: true }),
+  ]);
+  connect.mockResolvedValue({
+    context: "prod",
+    server: "https://prod:6443",
+    version: "v1.33.1",
+    platform: "linux/arm64",
+  });
+});
+
+describe("ContextPicker", () => {
+  it("lists every context in the kubeconfig", async () => {
+    renderPicker();
+    expect(await screen.findByText("prod")).toBeInTheDocument();
+    expect(screen.getByText("staging")).toBeInTheDocument();
+    // The cluster and default namespace disambiguate contexts that are
+    // named alike across files.
+    expect(screen.getByText(/prod-cluster · payments/)).toBeInTheDocument();
+  });
+
+  it("marks what kubectl would have used", async () => {
+    // So the obvious choice is the same one the terminal in the next
+    // window is pointed at.
+    renderPicker();
+    expect(await screen.findByText("kubeconfig default")).toBeInTheDocument();
+  });
+
+  it("marks the live connection rather than the kubeconfig default", async () => {
+    // When switching clusters, "connected" is the more useful label, and
+    // showing both on different rows would be ambiguous.
+    renderPicker({
+      current: {
+        context: "prod",
+        server: "https://prod:6443",
+        version: "v1.33.1",
+        platform: "linux/arm64",
+      },
+    });
+    expect(await screen.findByText("connected")).toBeInTheDocument();
+  });
+
+  it("connects to the context that was clicked", async () => {
+    const { user, onConnected } = renderPicker();
+    await user.click(await screen.findByText("prod"));
+
+    await waitFor(() => expect(connect).toHaveBeenCalledWith("prod"));
+    await waitFor(() => expect(onConnected).toHaveBeenCalledOnce());
+  });
+
+  it("reports a failed connection without losing the list", async () => {
+    // A cluster being unreachable is the normal case on a laptop. The
+    // other contexts must stay clickable.
+    connect.mockRejectedValue({
+      kind: "kubernetes",
+      message: "error trying to connect: tcp connect error",
+    });
+
+    const { user, onConnected } = renderPicker();
+    await user.click(await screen.findByText("prod"));
+
+    expect(await screen.findByText(/tcp connect error/)).toBeInTheDocument();
+    expect(onConnected).not.toHaveBeenCalled();
+    expect(screen.getByText("staging")).toBeInTheDocument();
+  });
+
+  it("explains an empty kubeconfig rather than showing nothing", async () => {
+    // A blank screen here reads as a broken app; naming KUBECONFIG is
+    // the actual next step.
+    listContexts.mockResolvedValue([]);
+    renderPicker();
+    expect(await screen.findByText(/No contexts found/)).toBeInTheDocument();
+    expect(screen.getByText("KUBECONFIG")).toBeInTheDocument();
+  });
+
+  it("reports a kubeconfig that could not be read", async () => {
+    listContexts.mockRejectedValue({
+      kind: "kubeconfig",
+      message: "kubeconfig: invalid YAML at line 4",
+    });
+    renderPicker();
+    expect(await screen.findByText(/invalid YAML/)).toBeInTheDocument();
+  });
+
+  it("offers a filter only once the list is long enough to need one", async () => {
+    renderPicker();
+    await screen.findByText("prod");
+    expect(
+      screen.queryByPlaceholderText("Filter contexts…"),
+    ).not.toBeInTheDocument();
+
+    listContexts.mockResolvedValue(
+      Array.from({ length: 8 }, (_, i) => context(`cluster-${i}`)),
+    );
+    renderPicker();
+    expect(
+      await screen.findByPlaceholderText("Filter contexts…"),
+    ).toBeInTheDocument();
+  });
+
+  it("filters on the cluster as well as the context name", async () => {
+    listContexts.mockResolvedValue([
+      ...Array.from({ length: 6 }, (_, i) => context(`ctx-${i}`)),
+      context("odd-name", { cluster: "eu-west-1-prod" }),
+    ]);
+
+    const { user } = renderPicker();
+    await user.type(
+      await screen.findByPlaceholderText("Filter contexts…"),
+      "eu-west",
+    );
+
+    expect(screen.getByText("odd-name")).toBeInTheDocument();
+    expect(screen.queryByText("ctx-0")).not.toBeInTheDocument();
+  });
+
+  it("says so when the filter matches nothing", async () => {
+    listContexts.mockResolvedValue(
+      Array.from({ length: 8 }, (_, i) => context(`ctx-${i}`)),
+    );
+    const { user } = renderPicker();
+    await user.type(
+      await screen.findByPlaceholderText("Filter contexts…"),
+      "zzz",
+    );
+    expect(screen.getByText(/Nothing matches/)).toBeInTheDocument();
+  });
+
+  it("can be dismissed with Escape when it is a switcher", async () => {
+    // As a launch screen there is nothing behind it to go back to, so
+    // Escape only means something when onCancel is given.
+    const onCancel = vi.fn();
+    const { user } = renderPicker({ onCancel });
+    await screen.findByText("prod");
+
+    await user.keyboard("{Escape}");
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("offers no cancel on the launch screen", async () => {
+    renderPicker();
+    await screen.findByText("prod");
+    expect(
+      screen.queryByRole("button", { name: "Cancel" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("blocks a second attempt while one is in flight", async () => {
+    // Two connects racing would leave the session pointing at whichever
+    // finished last, which is not necessarily the one that was clicked.
+    connect.mockImplementation(() => new Promise(() => {}));
+    const { user } = renderPicker();
+    await user.click(await screen.findByText("prod"));
+
+    await waitFor(() =>
+      expect(screen.getByText("Connecting…")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("staging").closest("button")).toBeDisabled();
+  });
+});

--- a/src/pages/Crds.test.tsx
+++ b/src/pages/Crds.test.tsx
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Crds, kindKey } from "./Crds";
+import { api, type ApiResourceInfo } from "../lib/api";
+
+// The index of every kind the cluster serves. It leads with custom
+// resources because the built-ins already have dedicated views, and an
+// unfiltered list of ~70 kinds buries the handful anyone came for.
+
+vi.mock("../lib/api", async (original) => {
+  const actual = await original<typeof import("../lib/api")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      listApiResources: vi.fn(),
+      refreshApiResources: vi.fn(),
+    },
+  };
+});
+
+const listApiResources = vi.mocked(api.listApiResources);
+const refreshApiResources = vi.mocked(api.refreshApiResources);
+
+function resource(overrides: Partial<ApiResourceInfo> = {}): ApiResourceInfo {
+  return {
+    group: "krypton.ai",
+    version: "v1alpha1",
+    kind: "Agent",
+    plural: "agents",
+    apiVersion: "krypton.ai/v1alpha1",
+    namespaced: true,
+    verbs: ["get", "list", "watch", "update"],
+    custom: true,
+    ...overrides,
+  };
+}
+
+const POD = resource({
+  group: "",
+  version: "v1",
+  kind: "Pod",
+  plural: "pods",
+  apiVersion: "v1",
+  custom: false,
+});
+
+function renderCrds() {
+  const onSelectKind = vi.fn();
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <Crds onSelectKind={onSelectKind} />
+    </QueryClientProvider>,
+  );
+  return { user: userEvent.setup(), onSelectKind };
+}
+
+beforeEach(() => {
+  listApiResources.mockReset();
+  refreshApiResources.mockReset();
+  listApiResources.mockResolvedValue([resource(), POD]);
+});
+
+describe("kindKey", () => {
+  it("keeps two versions of one kind distinct", () => {
+    // A CRD served at both v1alpha1 and v1 is two rows, and one key for
+    // both would collapse them or cross-wire the query cache.
+    expect(kindKey(resource({ version: "v1alpha1" }))).not.toBe(
+      kindKey(resource({ version: "v1" })),
+    );
+  });
+
+  it("keeps the same kind in two groups distinct", () => {
+    expect(kindKey(resource({ group: "a.io" }))).not.toBe(
+      kindKey(resource({ group: "b.io" })),
+    );
+  });
+});
+
+describe("Crds", () => {
+  it("leads with custom resources and holds the built-ins back", async () => {
+    renderCrds();
+    expect(await screen.findByText("Agent")).toBeInTheDocument();
+    expect(screen.queryByText("Pod")).not.toBeInTheDocument();
+  });
+
+  it("shows the built-ins when asked", async () => {
+    const { user } = renderCrds();
+    await screen.findByText("Agent");
+
+    await user.selectOptions(screen.getByRole("combobox"), "all");
+    expect(screen.getByText("Pod")).toBeInTheDocument();
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+  });
+
+  it("names the core group rather than showing a blank cell", async () => {
+    const { user } = renderCrds();
+    await screen.findByText("Agent");
+    await user.selectOptions(screen.getByRole("combobox"), "all");
+
+    expect(screen.getByText("core")).toBeInTheDocument();
+  });
+
+  it("says whether a kind can be edited before it is opened", async () => {
+    // Better than finding no Edit button after opening one.
+    listApiResources.mockResolvedValue([
+      resource({ kind: "Agent", verbs: ["get", "list", "update"] }),
+      resource({ kind: "AgentRun", verbs: ["get", "list"] }),
+    ]);
+
+    renderCrds();
+    expect(await screen.findByText("read/write")).toBeInTheDocument();
+    expect(screen.getByText("read-only")).toBeInTheDocument();
+  });
+
+  it("says whether a kind is namespaced", async () => {
+    listApiResources.mockResolvedValue([
+      resource({ kind: "Agent", namespaced: true }),
+      resource({ kind: "ClusterAgent", namespaced: false }),
+    ]);
+
+    renderCrds();
+    expect(await screen.findByText("Namespaced")).toBeInTheDocument();
+    expect(screen.getByText("Cluster")).toBeInTheDocument();
+  });
+
+  it("reports a chosen kind upward rather than opening it here", async () => {
+    // The sidebar picks kinds too, and two owners of one selection drift
+    // apart the moment either changes it.
+    const { user, onSelectKind } = renderCrds();
+    await user.click(await screen.findByText("Agent"));
+
+    expect(onSelectKind).toHaveBeenCalledWith({
+      id: "krypton.ai/v1alpha1/Agent",
+      label: "Agent",
+      gvk: { group: "krypton.ai", version: "v1alpha1", kind: "Agent" },
+    });
+  });
+
+  it("rediscovers rather than refetching a cache", async () => {
+    // This button exists for the CRD installed a minute ago, which a
+    // cached discovery cannot see however many times it is re-read.
+    refreshApiResources.mockResolvedValue([resource({ kind: "NewCrd" })]);
+
+    const { user } = renderCrds();
+    await screen.findByText("Agent");
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => expect(refreshApiResources).toHaveBeenCalledOnce());
+    expect(await screen.findByText("NewCrd")).toBeInTheDocument();
+  });
+
+  it("points at the built-ins when no CRDs are installed", async () => {
+    // A bare "nothing here" would look like discovery failed.
+    listApiResources.mockResolvedValue([POD]);
+    renderCrds();
+    expect(
+      await screen.findByText(/No custom resources are installed/),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces a discovery failure", async () => {
+    listApiResources.mockRejectedValue({
+      kind: "not_connected",
+      message: "not connected to a cluster",
+    });
+    renderCrds();
+    expect(await screen.findByText(/not connected/)).toBeInTheDocument();
+  });
+});

--- a/src/pages/Helm.test.tsx
+++ b/src/pages/Helm.test.tsx
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Helm } from "./Helm";
+import {
+  api,
+  type ReleaseDetail,
+  type ReleaseSummary,
+} from "../lib/api";
+
+// Helm releases, read out of the release Secrets rather than from the
+// CLI. What matters on screen is which revision is live, what was
+// actually overridden, and the notes — which are usually the only place
+// a chart says how to reach what it installed.
+
+vi.mock("../lib/api", async (original) => {
+  const actual = await original<typeof import("../lib/api")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      listHelmReleases: vi.fn(),
+      getHelmRelease: vi.fn(),
+      listNamespaces: vi.fn(),
+    },
+  };
+});
+
+const listHelmReleases = vi.mocked(api.listHelmReleases);
+const getHelmRelease = vi.mocked(api.getHelmRelease);
+const listNamespaces = vi.mocked(api.listNamespaces);
+
+function summary(overrides: Partial<ReleaseSummary> = {}): ReleaseSummary {
+  return {
+    name: "prom",
+    namespace: "monitoring",
+    revision: 3,
+    status: "deployed",
+    chart: "kube-prometheus-stack-85.3.3",
+    appVersion: "v0.87.0",
+    updated: "2d",
+    description: "Upgrade complete",
+    ...overrides,
+  };
+}
+
+function detail(overrides: Partial<ReleaseDetail> = {}): ReleaseDetail {
+  return {
+    name: "prom",
+    namespace: "monitoring",
+    revision: 3,
+    status: "deployed",
+    chart: "kube-prometheus-stack-85.3.3",
+    chartName: "kube-prometheus-stack",
+    chartVersion: "85.3.3",
+    appVersion: "v0.87.0",
+    updated: "2d",
+    firstDeployed: "40d",
+    description: "Upgrade complete",
+    chartDescription: "collects Kubernetes manifests",
+    home: "https://github.com/prometheus-operator",
+    notes: "browse http://localhost:3000",
+    values: "grafana:\n  enabled: true\n",
+    manifest: "apiVersion: v1\nkind: Service\n",
+    history: [
+      {
+        revision: 3,
+        status: "deployed",
+        chart: "kube-prometheus-stack-85.3.3",
+        appVersion: "v0.87.0",
+        updated: "2d",
+        description: "Upgrade complete",
+      },
+      {
+        revision: 2,
+        status: "superseded",
+        chart: "kube-prometheus-stack-85.0.0",
+        appVersion: "v0.86.0",
+        updated: "20d",
+        description: "Upgrade complete",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function renderHelm() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <Helm />
+    </QueryClientProvider>,
+  );
+  return userEvent.setup();
+}
+
+/// Opens the release detail from the list.
+async function openRelease(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(await screen.findByText("prom"));
+  await waitFor(() => expect(getHelmRelease).toHaveBeenCalled());
+}
+
+beforeEach(() => {
+  listHelmReleases.mockReset().mockResolvedValue([summary()]);
+  getHelmRelease.mockReset().mockResolvedValue(detail());
+  listNamespaces
+    .mockReset()
+    .mockResolvedValue([{ name: "monitoring", phase: "Active", age: "60d" }]);
+});
+
+describe("Helm release list", () => {
+  it("lists releases the way helm list prints them", async () => {
+    renderHelm();
+    expect(await screen.findByText("prom")).toBeInTheDocument();
+    expect(screen.getByText("kube-prometheus-stack-85.3.3")).toBeInTheDocument();
+    expect(screen.getByText("v0.87.0")).toBeInTheDocument();
+    expect(screen.getByText("deployed")).toBeInTheDocument();
+  });
+
+  it("explains an empty list rather than implying Helm is unused", async () => {
+    // A cluster configured with HELM_DRIVER=configmap keeps its releases
+    // somewhere Loupe does not read, and "no releases" would be wrong.
+    listHelmReleases.mockResolvedValue([]);
+    renderHelm();
+    expect(await screen.findByText(/secret driver/)).toBeInTheDocument();
+  });
+
+  it("narrows to one namespace when picked", async () => {
+    const user = renderHelm();
+    await screen.findByText("prom");
+
+    await user.selectOptions(screen.getByRole("combobox"), "monitoring");
+    await waitFor(() =>
+      expect(listHelmReleases).toHaveBeenCalledWith("monitoring"),
+    );
+  });
+
+  it("surfaces a failure to list", async () => {
+    listHelmReleases.mockRejectedValue({
+      kind: "kubernetes",
+      message: 'secrets is forbidden: User "dev" cannot list resource "secrets"',
+    });
+    renderHelm();
+    expect(await screen.findByText(/forbidden/)).toBeInTheDocument();
+  });
+});
+
+describe("Helm release detail", () => {
+  it("opens the release that was clicked", async () => {
+    const user = renderHelm();
+    await openRelease(user);
+    expect(getHelmRelease).toHaveBeenCalledWith("monitoring", "prom");
+  });
+
+  it("leads with the live revision", async () => {
+    const user = renderHelm();
+    await openRelease(user);
+    expect(await screen.findByText("rev 3")).toBeInTheDocument();
+    expect(screen.getByText("kube-prometheus-stack")).toBeInTheDocument();
+    expect(screen.getByText("85.3.3")).toBeInTheDocument();
+  });
+
+  it("shows what was overridden, not the chart's defaults", async () => {
+    // `helm get values` makes the same distinction, and it is the one
+    // that answers "what did we actually configure".
+    const user = renderHelm();
+    await openRelease(user);
+    await user.click(screen.getByRole("button", { name: "Values" }));
+
+    expect(await screen.findByText(/grafana/)).toBeInTheDocument();
+  });
+
+  it("says so when a release runs the chart's defaults", async () => {
+    // An empty YAML pane would read as a failure to load.
+    getHelmRelease.mockResolvedValue(detail({ values: "" }));
+    const user = renderHelm();
+    await openRelease(user);
+    await user.click(screen.getByRole("button", { name: "Values" }));
+
+    expect(
+      await screen.findByText(/No values were overridden/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the notes as written", async () => {
+    // Usually the only place a chart says how to reach what it just
+    // installed, and the line breaks in it are meaningful.
+    const user = renderHelm();
+    await openRelease(user);
+    await user.click(screen.getByRole("button", { name: "Notes" }));
+
+    expect(await screen.findByText(/localhost:3000/)).toBeInTheDocument();
+  });
+
+  it("says so when a chart ships no notes", async () => {
+    getHelmRelease.mockResolvedValue(detail({ notes: null }));
+    const user = renderHelm();
+    await openRelease(user);
+    await user.click(screen.getByRole("button", { name: "Notes" }));
+
+    expect(await screen.findByText(/ships no notes/)).toBeInTheDocument();
+  });
+
+  it("reads its history backwards in time", async () => {
+    // The way `helm history` prints it: the current revision at the top.
+    const user = renderHelm();
+    await openRelease(user);
+    await user.click(screen.getByRole("button", { name: "History" }));
+
+    expect(await screen.findByText("superseded")).toBeInTheDocument();
+    const revisions = screen
+      .getAllByRole("row")
+      .slice(1)
+      .map((r) => r.textContent);
+    expect(revisions[0]).toContain("3");
+    expect(revisions[1]).toContain("2");
+  });
+
+  it("renders the manifest that was applied", async () => {
+    const user = renderHelm();
+    await openRelease(user);
+    await user.click(screen.getByRole("button", { name: "Manifest" }));
+
+    expect(await screen.findByText(/Service/)).toBeInTheDocument();
+  });
+});

--- a/src/pages/NamespaceDetail.test.tsx
+++ b/src/pages/NamespaceDetail.test.tsx
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NamespaceDetail } from "./NamespaceDetail";
+import { api, type NamespaceDetail as NamespaceDetailData } from "../lib/api";
+
+// A Namespace object is almost empty — a phase and some finalizers. The
+// questions people open one to answer are about its contents: how many
+// pods are unhealthy, and whether a quota is why nothing new will start.
+
+vi.mock("../lib/api", async (original) => {
+  const actual = await original<typeof import("../lib/api")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getNamespace: vi.fn(),
+      listPods: vi.fn(),
+      listNamespaceEvents: vi.fn(),
+    },
+  };
+});
+
+const getNamespace = vi.mocked(api.getNamespace);
+const listPods = vi.mocked(api.listPods);
+const listNamespaceEvents = vi.mocked(api.listNamespaceEvents);
+
+function namespace(
+  overrides: Partial<NamespaceDetailData> = {},
+): NamespaceDetailData {
+  return {
+    apiVersion: "v1",
+    kind: "Namespace",
+    name: "prod",
+    phase: "Active",
+    age: "120d",
+    labels: [],
+    annotations: [],
+    finalizers: [],
+    podCount: 3,
+    podsByPhase: [
+      { phase: "Running", count: 2 },
+      { phase: "Failed", count: 1 },
+    ],
+    quotas: [],
+    yaml: "apiVersion: v1\nkind: Namespace\n",
+    ...overrides,
+  };
+}
+
+function renderDetail(onOpenPod?: () => void) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <NamespaceDetail name="prod" onClose={vi.fn()} onOpenPod={onOpenPod} />
+    </QueryClientProvider>,
+  );
+  return userEvent.setup();
+}
+
+beforeEach(() => {
+  getNamespace.mockReset();
+  listPods.mockReset();
+  listNamespaceEvents.mockReset();
+
+  getNamespace.mockResolvedValue(namespace());
+  listPods.mockResolvedValue([]);
+  listNamespaceEvents.mockResolvedValue([]);
+});
+
+describe("NamespaceDetail", () => {
+  it("breaks the pod count down by phase", async () => {
+    // "3 pods" does not say whether anything is wrong; "1 Failed" does.
+    renderDetail();
+    expect(await screen.findByText("2 Running")).toBeInTheDocument();
+    expect(screen.getByText("1 Failed")).toBeInTheDocument();
+  });
+
+  it("says None rather than showing an empty row for an empty namespace", async () => {
+    getNamespace.mockResolvedValue(
+      namespace({ podCount: 0, podsByPhase: [] }),
+    );
+    renderDetail();
+    expect(await screen.findByText("None")).toBeInTheDocument();
+  });
+
+  it("counts one pod in the singular", async () => {
+    getNamespace.mockResolvedValue(
+      namespace({ podCount: 1, podsByPhase: [{ phase: "Running", count: 1 }] }),
+    );
+    renderDetail();
+    expect(await screen.findByText("1 pod")).toBeInTheDocument();
+  });
+
+  it("names the finalizers holding up a deletion", async () => {
+    // A namespace that will not go away is always a finalizer nobody is
+    // answering for, and naming it is the entire diagnosis.
+    getNamespace.mockResolvedValue(
+      namespace({
+        phase: "Terminating",
+        finalizers: ["custom.io/cleanup"],
+      }),
+    );
+
+    renderDetail();
+    expect(await screen.findByText(/deletion is waiting on these/)).toBeInTheDocument();
+    expect(screen.getByText("custom.io/cleanup")).toBeInTheDocument();
+  });
+
+  it("does not dramatise finalizers on a healthy namespace", async () => {
+    // Every namespace has the `kubernetes` finalizer. Heading it with
+    // "deletion is waiting" on an Active namespace would read as alarm.
+    getNamespace.mockResolvedValue(
+      namespace({ phase: "Active", finalizers: ["kubernetes"] }),
+    );
+
+    renderDetail();
+    expect(await screen.findByText("Finalizers")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/deletion is waiting on these/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("omits the finalizers section when there are none", async () => {
+    renderDetail();
+    await screen.findByText("2 Running");
+    expect(screen.queryByText(/Finalizer/)).not.toBeInTheDocument();
+  });
+
+  it("lists the pods in this namespace alone", async () => {
+    const user = renderDetail();
+    await screen.findByText("2 Running");
+    await user.click(screen.getByRole("button", { name: "Pods" }));
+
+    expect(listPods).toHaveBeenCalledWith("prod");
+  });
+
+  it("shows everything happening in the namespace, not to it", async () => {
+    // A namespace object almost never has events of its own, so
+    // filtering by involvedObject here would render an empty tab.
+    const user = renderDetail();
+    await screen.findByText("2 Running");
+    await user.click(screen.getByRole("button", { name: "Events" }));
+
+    expect(listNamespaceEvents).toHaveBeenCalledWith("prod");
+  });
+
+  it("surfaces a failure to read the namespace", async () => {
+    getNamespace.mockRejectedValue({
+      kind: "kubernetes",
+      message: 'namespaces "prod" is forbidden',
+    });
+    renderDetail();
+    expect(await screen.findByText(/forbidden/)).toBeInTheDocument();
+  });
+});

--- a/src/pages/NodeDetail.test.tsx
+++ b/src/pages/NodeDetail.test.tsx
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NodeDetail } from "./NodeDetail";
+import { api, type NodeDetail as NodeDetailData } from "../lib/api";
+
+// The page that answers "why will nothing schedule here". The three
+// answers are a taint, a pressure condition, and requests that have
+// already claimed the allocatable CPU — so those are what is asserted.
+
+vi.mock("../lib/api", async (original) => {
+  const actual = await original<typeof import("../lib/api")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getNode: vi.fn(),
+      listPodsOnNode: vi.fn(),
+      listEvents: vi.fn(),
+    },
+  };
+});
+
+const getNode = vi.mocked(api.getNode);
+const listPodsOnNode = vi.mocked(api.listPodsOnNode);
+const listEvents = vi.mocked(api.listEvents);
+
+function node(overrides: Partial<NodeDetailData> = {}): NodeDetailData {
+  return {
+    apiVersion: "v1",
+    kind: "Node",
+    name: "worker-1",
+    ready: true,
+    schedulable: true,
+    roles: ["worker"],
+    version: "v1.33.1",
+    age: "65d",
+    addresses: [["InternalIP", "10.0.0.4"]],
+    osImage: "Debian GNU/Linux 12",
+    kernelVersion: "6.1.0",
+    containerRuntime: "containerd://2.0.0",
+    architecture: "arm64",
+    operatingSystem: "linux",
+    capacity: [["cpu", "8"]],
+    allocatable: [["cpu", "7800m"]],
+    allocated: [
+      {
+        name: "CPU",
+        requests: "4",
+        requestsPercent: 51,
+        limits: "6",
+        limitsPercent: 76,
+        allocatable: "7800m",
+      },
+    ],
+    taints: [],
+    conditions: [],
+    labels: [],
+    annotations: [],
+    podCount: 12,
+    yaml: "apiVersion: v1\nkind: Node\n",
+    ...overrides,
+  };
+}
+
+function renderDetail() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <NodeDetail name="worker-1" onClose={vi.fn()} />
+    </QueryClientProvider>,
+  );
+  return userEvent.setup();
+}
+
+beforeEach(() => {
+  getNode.mockReset();
+  listPodsOnNode.mockReset();
+  listEvents.mockReset();
+
+  getNode.mockResolvedValue(node());
+  listPodsOnNode.mockResolvedValue([]);
+  listEvents.mockResolvedValue([]);
+});
+
+describe("NodeDetail", () => {
+  it("shows the machine's identity", async () => {
+    renderDetail();
+    expect(await screen.findByText("v1.33.1")).toBeInTheDocument();
+    expect(screen.getByText("Debian GNU/Linux 12")).toBeInTheDocument();
+    expect(screen.getByText("containerd://2.0.0")).toBeInTheDocument();
+    expect(screen.getByText("linux/arm64")).toBeInTheDocument();
+  });
+
+  it("shows Ready and Cordoned side by side", async () => {
+    // A cordoned node is still Ready. Showing only one of them makes the
+    // page contradict either itself or the reason nothing is landing.
+    getNode.mockResolvedValue(node({ ready: true, schedulable: false }));
+    renderDetail();
+
+    expect(await screen.findByText("Ready")).toBeInTheDocument();
+    expect(screen.getByText("Cordoned")).toBeInTheDocument();
+  });
+
+  it("says nothing about cordoning when the node is schedulable", async () => {
+    renderDetail();
+    await screen.findByText("Ready");
+    expect(screen.queryByText("Cordoned")).not.toBeInTheDocument();
+  });
+
+  it("shows taints, which are usually the answer", async () => {
+    getNode.mockResolvedValue(
+      node({ taints: ["dedicated=gpu:NoSchedule", "node.kubernetes.io/unreachable:NoExecute"] }),
+    );
+    renderDetail();
+
+    expect(await screen.findByText("Taints")).toBeInTheDocument();
+    expect(screen.getByText("dedicated=gpu:NoSchedule")).toBeInTheDocument();
+  });
+
+  it("omits the taints section on an untainted node", async () => {
+    renderDetail();
+    await screen.findByText("v1.33.1");
+    expect(screen.queryByText("Taints")).not.toBeInTheDocument();
+  });
+
+  it("does not paint a healthy node red over its pressure conditions", async () => {
+    // Ready is healthy when True; every other node condition is a
+    // pressure signal and is healthy when False. Treating them alike
+    // would show a working node as four warnings.
+    getNode.mockResolvedValue(
+      node({
+        conditions: [
+          { type: "Ready", status: "True", reason: "KubeletReady", message: null },
+          { type: "MemoryPressure", status: "False", reason: null, message: null },
+          { type: "DiskPressure", status: "False", reason: null, message: null },
+        ],
+      }),
+    );
+
+    renderDetail();
+    expect(await screen.findByText("Ready: True")).toBeInTheDocument();
+    expect(screen.getByText("MemoryPressure: False")).toBeInTheDocument();
+  });
+
+  it("shows the message on a condition that has tripped", async () => {
+    getNode.mockResolvedValue(
+      node({
+        conditions: [
+          {
+            type: "MemoryPressure",
+            status: "True",
+            reason: "KubeletHasInsufficientMemory",
+            message: "kubelet has insufficient memory available",
+          },
+        ],
+      }),
+    );
+
+    renderDetail();
+    expect(
+      await screen.findByText(/insufficient memory available/),
+    ).toBeInTheDocument();
+  });
+
+  it("measures allocation against allocatable, not capacity", async () => {
+    // The kubelet reserves part of the machine for itself. Showing
+    // capacity here would flatter every node.
+    renderDetail();
+    expect(await screen.findByText("Allocated resources")).toBeInTheDocument();
+    expect(screen.getByText(/scheduler has to give/)).toBeInTheDocument();
+    expect(screen.getByText("7800m")).toBeInTheDocument();
+  });
+
+  it("lists the pods scheduled onto this node, not the whole cluster", async () => {
+    // The difference on a real cluster is thirty rows versus thirty
+    // thousand, and it is filtered server-side.
+    const user = renderDetail();
+    await screen.findByText("v1.33.1");
+    await user.click(screen.getByRole("button", { name: "Pods" }));
+
+    expect(listPodsOnNode).toHaveBeenCalledWith("worker-1");
+  });
+
+  it("looks for a node's events in the default namespace", async () => {
+    // A node is cluster-scoped, but the kubelet writes its events into
+    // "default". Filtering on the node's own (absent) namespace would
+    // show an empty tab on every node.
+    const user = renderDetail();
+    await screen.findByText("v1.33.1");
+    await user.click(screen.getByRole("button", { name: "Events" }));
+
+    expect(listEvents).toHaveBeenCalledWith("default", "worker-1");
+  });
+
+  it("surfaces a failure to read the node", async () => {
+    getNode.mockRejectedValue({
+      kind: "kubernetes",
+      message: 'nodes "worker-1" not found',
+    });
+    renderDetail();
+    expect(await screen.findByText(/not found/)).toBeInTheDocument();
+  });
+});

--- a/src/pages/ObjectDetail.test.tsx
+++ b/src/pages/ObjectDetail.test.tsx
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ObjectDetail } from "./ObjectDetail";
+import { api, type GvkRef, type ObjectDetail as ObjectDetailData } from "../lib/api";
+
+// Detail for a kind nothing knew about at compile time. Two things here
+// are worth more than the rest: a Secret must reach the Data tab rather
+// than the YAML, and a read-only object must not be offered an editor.
+
+vi.mock("../lib/api", async (original) => {
+  const actual = await original<typeof import("../lib/api")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getObject: vi.fn(),
+      getSecretData: vi.fn(),
+      getConfigMapData: vi.fn(),
+      listEvents: vi.fn(),
+    },
+  };
+});
+
+const getObject = vi.mocked(api.getObject);
+const getSecretData = vi.mocked(api.getSecretData);
+const listEvents = vi.mocked(api.listEvents);
+
+const AGENT: GvkRef = {
+  group: "krypton.ai",
+  version: "v1alpha1",
+  kind: "Agent",
+};
+const SECRET: GvkRef = { group: "", version: "v1", kind: "Secret" };
+
+function object(overrides: Partial<ObjectDetailData> = {}): ObjectDetailData {
+  return {
+    apiVersion: "krypton.ai/v1alpha1",
+    kind: "Agent",
+    name: "mcp-hello",
+    namespace: "agents",
+    age: "65d",
+    status: "Ready",
+    labels: [],
+    annotations: [],
+    conditions: [],
+    editable: true,
+    yaml: "apiVersion: krypton.ai/v1alpha1\nkind: Agent\n",
+    ...overrides,
+  };
+}
+
+function renderDetail(
+  resource: GvkRef = AGENT,
+  namespace: string | null = "agents",
+) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <ObjectDetail
+        resource={resource}
+        namespace={namespace}
+        name={resource.kind === "Secret" ? "db-credentials" : "mcp-hello"}
+        onClose={vi.fn()}
+      />
+    </QueryClientProvider>,
+  );
+  return userEvent.setup();
+}
+
+beforeEach(() => {
+  getObject.mockReset().mockResolvedValue(object());
+  getSecretData.mockReset().mockResolvedValue({
+    type: "Opaque",
+    redacted: true,
+    keys: [{ key: "password", bytes: 7, value: null, binary: false }],
+  });
+  vi.mocked(api.getConfigMapData).mockReset();
+  listEvents.mockReset().mockResolvedValue([]);
+});
+
+describe("ObjectDetail", () => {
+  it("shows what the API conventions promise and nothing invented", async () => {
+    renderDetail();
+    expect(await screen.findByText("Agent")).toBeInTheDocument();
+    expect(screen.getByText("krypton.ai/v1alpha1")).toBeInTheDocument();
+    expect(screen.getByText("agents")).toBeInTheDocument();
+  });
+
+  it("shows a condition's reason and message", async () => {
+    getObject.mockResolvedValue(
+      object({
+        status: "NotReady: ModelPullFailed",
+        conditions: [
+          {
+            type: "Ready",
+            status: "False",
+            reason: "ModelPullFailed",
+            message: "could not pull qwen2:0.5b",
+          },
+        ],
+      }),
+    );
+
+    renderDetail();
+    expect(await screen.findByText("Ready: False")).toBeInTheDocument();
+    expect(screen.getByText("ModelPullFailed")).toBeInTheDocument();
+    expect(screen.getByText(/could not pull/)).toBeInTheDocument();
+  });
+
+  it("gives a Secret its own Data tab", async () => {
+    // A Secret is opened to read its contents. Sending people to the
+    // YAML — where the values are redacted — would be a dead end.
+    getObject.mockResolvedValue(
+      object({
+        apiVersion: "v1",
+        kind: "Secret",
+        name: "db-credentials",
+        namespace: "prod",
+        editable: false,
+        status: null,
+      }),
+    );
+
+    const user = renderDetail(SECRET, "prod");
+    await screen.findByText("Secret");
+    await user.click(screen.getByRole("button", { name: "Data" }));
+
+    expect(await screen.findByText("password")).toBeInTheDocument();
+    expect(getSecretData).toHaveBeenCalledWith("prod", "db-credentials", []);
+  });
+
+  it("explains why a Secret's YAML cannot be applied", async () => {
+    // "Read-only" alone would look like an RBAC problem. The real reason
+    // is that saving redacted text would overwrite every value.
+    getObject.mockResolvedValue(
+      object({
+        apiVersion: "v1",
+        kind: "Secret",
+        name: "db-credentials",
+        namespace: "prod",
+        editable: false,
+        status: null,
+      }),
+    );
+
+    renderDetail(SECRET, "prod");
+    expect(
+      await screen.findByText(/overwrite every value with the placeholder/),
+    ).toBeInTheDocument();
+  });
+
+  it("names the kind when the cluster will not accept updates", async () => {
+    getObject.mockResolvedValue(object({ editable: false }));
+    renderDetail();
+    expect(
+      await screen.findByText(/does not accept updates to Agent/),
+    ).toBeInTheDocument();
+  });
+
+  it("gives no Data tab to a kind that holds no key/value map", async () => {
+    renderDetail();
+    await screen.findByText("Agent");
+    expect(screen.queryByRole("button", { name: "Data" })).not.toBeInTheDocument();
+  });
+
+  it("gives no Events tab to a cluster-scoped object", async () => {
+    // There is no namespace to look for events in, and guessing
+    // "default" would show somebody else's.
+    getObject.mockResolvedValue(
+      object({ namespace: null, kind: "ClusterAgent" }),
+    );
+    renderDetail({ ...AGENT, kind: "ClusterAgent" }, null);
+
+    await screen.findByText("ClusterAgent");
+    expect(
+      screen.queryByRole("button", { name: "Events" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("filters events to this object", async () => {
+    const user = renderDetail();
+    await screen.findByText("Agent");
+    await user.click(screen.getByRole("button", { name: "Events" }));
+
+    expect(listEvents).toHaveBeenCalledWith("agents", "mcp-hello");
+  });
+
+  it("surfaces a failure to read the object", async () => {
+    getObject.mockRejectedValue({
+      kind: "unknown_resource",
+      message: "Agent (krypton.ai/v1alpha1) is not served by this cluster",
+    });
+    renderDetail();
+    expect(await screen.findByText(/not served by this cluster/)).toBeInTheDocument();
+  });
+});

--- a/src/pages/PodDetail.test.tsx
+++ b/src/pages/PodDetail.test.tsx
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { PodDetail } from "./PodDetail";
+import { api, type ContainerView, type PodDetail as PodDetailData } from "../lib/api";
+
+// The page an operator opens when a pod is misbehaving. What is asserted
+// here is that the things explaining *why* survive the trip to the
+// screen — the previous container state, the restart count, and the
+// separation of init containers from app containers.
+
+vi.mock("../lib/api", async (original) => {
+  const actual = await original<typeof import("../lib/api")>();
+  return {
+    ...actual,
+    Channel: class {
+      onmessage?: (event: unknown) => void;
+    },
+    api: {
+      ...actual.api,
+      getPod: vi.fn(),
+      listEvents: vi.fn(),
+      startPodLogs: vi.fn(),
+      stopPodLogs: vi.fn(),
+    },
+  };
+});
+
+const getPod = vi.mocked(api.getPod);
+const listEvents = vi.mocked(api.listEvents);
+const startPodLogs = vi.mocked(api.startPodLogs);
+
+function container(overrides: Partial<ContainerView> = {}): ContainerView {
+  return {
+    name: "app",
+    image: "app:1.0",
+    ready: true,
+    restarts: 0,
+    state: "Running",
+    lastState: null,
+    ...overrides,
+  };
+}
+
+function pod(overrides: Partial<PodDetailData> = {}): PodDetailData {
+  return {
+    apiVersion: "v1",
+    kind: "Pod",
+    name: "web-abc",
+    namespace: "prod",
+    phase: "Running",
+    node: "worker-1",
+    podIp: "10.1.2.3",
+    serviceAccount: "default",
+    qosClass: "Burstable",
+    age: "3d",
+    labels: [["app", "web"]],
+    annotations: [],
+    containers: [container()],
+    initContainers: [],
+    conditions: [],
+    yaml: "apiVersion: v1\nkind: Pod\n",
+    ...overrides,
+  };
+}
+
+function renderDetail() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <PodDetail namespace="prod" name="web-abc" onClose={vi.fn()} />
+    </QueryClientProvider>,
+  );
+  return userEvent.setup();
+}
+
+beforeEach(() => {
+  getPod.mockReset();
+  listEvents.mockReset();
+  startPodLogs.mockReset();
+
+  getPod.mockResolvedValue(pod());
+  listEvents.mockResolvedValue([]);
+  startPodLogs.mockResolvedValue(1);
+});
+
+describe("PodDetail overview", () => {
+  it("shows where the pod is running", async () => {
+    renderDetail();
+    expect(await screen.findByText("worker-1")).toBeInTheDocument();
+    expect(screen.getByText("10.1.2.3")).toBeInTheDocument();
+    expect(screen.getByText("Burstable")).toBeInTheDocument();
+  });
+
+  it("explains a crash loop with the previous container state", async () => {
+    // CrashLoopBackOff says the container keeps dying. The previous
+    // state says why, and without it the next step is guesswork.
+    getPod.mockResolvedValue(
+      pod({
+        phase: "Running",
+        containers: [
+          container({
+            ready: false,
+            restarts: 7,
+            state: "Waiting: CrashLoopBackOff",
+            lastState: "Terminated: OOMKilled (exit 137)",
+          }),
+        ],
+      }),
+    );
+
+    renderDetail();
+    expect(
+      await screen.findByText("Waiting: CrashLoopBackOff"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/previously.*OOMKilled/)).toBeInTheDocument();
+    expect(screen.getByText("7 restarts")).toBeInTheDocument();
+  });
+
+  it("says restart rather than restarts for a single one", async () => {
+    getPod.mockResolvedValue(
+      pod({ containers: [container({ restarts: 1 })] }),
+    );
+    renderDetail();
+    expect(await screen.findByText("1 restart")).toBeInTheDocument();
+  });
+
+  it("does not show a restart count for a pod that has not restarted", async () => {
+    // A "0 restarts" chip on every healthy pod is noise.
+    renderDetail();
+    await screen.findByText("worker-1");
+    expect(screen.queryByText(/restart/)).not.toBeInTheDocument();
+  });
+
+  it("keeps init containers separate from app containers", async () => {
+    // An init container stuck pulling its image is a common reason a pod
+    // never starts, and merging the lists hides which phase it is in.
+    getPod.mockResolvedValue(
+      pod({
+        phase: "Pending",
+        initContainers: [
+          container({ name: "migrate", state: "Waiting: ImagePullBackOff", ready: false }),
+        ],
+      }),
+    );
+
+    renderDetail();
+    expect(await screen.findByText("Init containers")).toBeInTheDocument();
+    expect(screen.getByText("Containers")).toBeInTheDocument();
+    expect(screen.getByText("migrate")).toBeInTheDocument();
+  });
+
+  it("omits the init containers section when there are none", async () => {
+    renderDetail();
+    await screen.findByText("worker-1");
+    expect(screen.queryByText("Init containers")).not.toBeInTheDocument();
+  });
+
+  it("shows the pod's phase beside its name", async () => {
+    getPod.mockResolvedValue(pod({ phase: "Pending" }));
+    renderDetail();
+    expect(await screen.findByText("Pending")).toBeInTheDocument();
+  });
+
+  it("shows a condition's message when it has one", async () => {
+    getPod.mockResolvedValue(
+      pod({
+        conditions: [
+          {
+            type: "PodScheduled",
+            status: "False",
+            reason: "Unschedulable",
+            message: "0/3 nodes are available: 3 Insufficient cpu.",
+          },
+        ],
+      }),
+    );
+
+    renderDetail();
+    expect(await screen.findByText(/Insufficient cpu/)).toBeInTheDocument();
+    expect(screen.getByText("PodScheduled: False")).toBeInTheDocument();
+  });
+
+  it("surfaces a failure to read the pod", async () => {
+    // A pod deleted while its page was open is the common case, and the
+    // page has to say so rather than sit on a skeleton forever.
+    getPod.mockRejectedValue({
+      kind: "kubernetes",
+      message: 'pods "web-abc" not found',
+    });
+    renderDetail();
+    expect(await screen.findByText(/not found/)).toBeInTheDocument();
+  });
+});
+
+describe("PodDetail tabs", () => {
+  it("streams logs from every container in the pod", async () => {
+    // Including init containers: their output is where an init failure
+    // explains itself, and it is unreachable from anywhere else.
+    getPod.mockResolvedValue(
+      pod({
+        initContainers: [container({ name: "migrate" })],
+        containers: [container({ name: "app" })],
+      }),
+    );
+
+    const user = renderDetail();
+    await screen.findByText("worker-1");
+    await user.click(screen.getByRole("button", { name: "Logs" }));
+
+    const picker = await screen.findByRole("combobox");
+    expect(picker).toHaveTextContent("migrate");
+    expect(picker).toHaveTextContent("app");
+  });
+
+  it("opens the events tab against this pod alone", async () => {
+    const user = renderDetail();
+    await screen.findByText("worker-1");
+    await user.click(screen.getByRole("button", { name: "Events" }));
+
+    expect(listEvents).toHaveBeenCalledWith("prod", "web-abc");
+  });
+
+  it("renders the YAML the server sent", async () => {
+    const user = renderDetail();
+    await screen.findByText("worker-1");
+    await user.click(screen.getByRole("button", { name: "YAML" }));
+
+    expect(await screen.findByText(/kind/)).toBeInTheDocument();
+  });
+});

--- a/src/pages/Resources.test.tsx
+++ b/src/pages/Resources.test.tsx
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactElement } from "react";
+import { Namespaces, Nodes, Pods } from "./Resources";
+import { api, type NodeSummary, type PodSummary } from "../lib/api";
+
+// The three built-in list views. Each is a table plus a detail view it
+// swaps to, so what is worth covering is the columns an operator scans,
+// and that clicking a row opens the right object.
+
+vi.mock("../lib/api", async (original) => {
+  const actual = await original<typeof import("../lib/api")>();
+  return {
+    ...actual,
+    Channel: class {
+      onmessage?: (event: unknown) => void;
+    },
+    api: {
+      ...actual.api,
+      listNodes: vi.fn(),
+      listNamespaces: vi.fn(),
+      listPods: vi.fn(),
+      getNode: vi.fn(),
+      getNamespace: vi.fn(),
+      getPod: vi.fn(),
+      listPodsOnNode: vi.fn(),
+      listEvents: vi.fn(),
+    },
+  };
+});
+
+const listNodes = vi.mocked(api.listNodes);
+const listNamespaces = vi.mocked(api.listNamespaces);
+const listPods = vi.mocked(api.listPods);
+const getNode = vi.mocked(api.getNode);
+const getPod = vi.mocked(api.getPod);
+
+function pod(overrides: Partial<PodSummary> = {}): PodSummary {
+  return {
+    name: "web-abc",
+    namespace: "prod",
+    phase: "Running",
+    node: "worker-1",
+    ready: "1/1",
+    restarts: 0,
+    age: "3d",
+    ...overrides,
+  };
+}
+
+function node(overrides: Partial<NodeSummary> = {}): NodeSummary {
+  return {
+    name: "worker-1",
+    ready: true,
+    roles: ["worker"],
+    version: "v1.33.1",
+    age: "65d",
+    ...overrides,
+  };
+}
+
+function renderPage(page: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(<QueryClientProvider client={client}>{page}</QueryClientProvider>);
+  return userEvent.setup();
+}
+
+beforeEach(() => {
+  vi.mocked(api.listEvents).mockResolvedValue([]);
+  vi.mocked(api.listPodsOnNode).mockResolvedValue([]);
+
+  listNodes.mockReset().mockResolvedValue([node()]);
+  listNamespaces
+    .mockReset()
+    .mockResolvedValue([{ name: "prod", phase: "Active", age: "120d" }]);
+  listPods.mockReset().mockResolvedValue([pod()]);
+
+  getNode.mockReset();
+  getPod.mockReset();
+  vi.mocked(api.getNamespace).mockReset();
+});
+
+describe("Nodes", () => {
+  it("lists nodes with their roles and readiness", async () => {
+    renderPage(<Nodes />);
+    expect(await screen.findByText("worker-1")).toBeInTheDocument();
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(screen.getByText("worker")).toBeInTheDocument();
+    expect(screen.getByText("v1.33.1")).toBeInTheDocument();
+  });
+
+  it("says NotReady rather than leaving the cell blank", async () => {
+    listNodes.mockResolvedValue([node({ ready: false })]);
+    renderPage(<Nodes />);
+    expect(await screen.findByText("NotReady")).toBeInTheDocument();
+  });
+
+  it("renders an em dash for a node with no age", async () => {
+    listNodes.mockResolvedValue([node({ age: null })]);
+    renderPage(<Nodes />);
+    expect(await screen.findByText("—")).toBeInTheDocument();
+  });
+
+  it("opens the node it was told to", async () => {
+    getNode.mockImplementation(() => new Promise(() => {}));
+    const user = renderPage(<Nodes />);
+    await user.click(await screen.findByText("worker-1"));
+
+    await waitFor(() => expect(getNode).toHaveBeenCalledWith("worker-1"));
+  });
+
+  it("surfaces a failure to list", async () => {
+    listNodes.mockRejectedValue({
+      kind: "kubernetes",
+      message: 'nodes is forbidden: User "dev" cannot list resource "nodes"',
+    });
+    renderPage(<Nodes />);
+    expect(await screen.findByText(/forbidden/)).toBeInTheDocument();
+  });
+});
+
+describe("Namespaces", () => {
+  it("lists namespaces with their phase", async () => {
+    renderPage(<Namespaces />);
+    expect(await screen.findByText("prod")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+
+  it("opens the namespace it was told to", async () => {
+    vi.mocked(api.getNamespace).mockImplementation(() => new Promise(() => {}));
+    const user = renderPage(<Namespaces />);
+    await user.click(await screen.findByText("prod"));
+
+    await waitFor(() =>
+      expect(api.getNamespace).toHaveBeenCalledWith("prod"),
+    );
+  });
+});
+
+describe("Pods", () => {
+  it("shows the columns an operator scans", async () => {
+    renderPage(<Pods />);
+    expect(await screen.findByText("web-abc")).toBeInTheDocument();
+    expect(screen.getByText("1/1")).toBeInTheDocument();
+    expect(screen.getByText("worker-1")).toBeInTheDocument();
+    expect(screen.getByText("Running")).toBeInTheDocument();
+  });
+
+  it("does not draw attention to a pod that has not restarted", async () => {
+    // A coloured 0 on every healthy row would train people to ignore
+    // the column that matters.
+    renderPage(<Pods />);
+    const zero = await screen.findByText("0");
+    expect(zero).toHaveClass("text-content-muted");
+  });
+
+  it("escalates a heavily restarting pod", async () => {
+    // Above five restarts the pod is not merely flapping; the column is
+    // scanned for exactly this.
+    listPods.mockResolvedValue([pod({ restarts: 12 })]);
+    renderPage(<Pods />);
+    expect(await screen.findByText("12")).toHaveClass("text-danger");
+  });
+
+  it("lists every namespace by default", async () => {
+    // Matching `kubectl get pods -A`, which is what the cluster-wide
+    // view is for.
+    renderPage(<Pods />);
+    await screen.findByText("web-abc");
+    expect(listPods).toHaveBeenCalledWith(undefined);
+    expect(screen.getByText("All namespaces")).toBeInTheDocument();
+  });
+
+  it("narrows to one namespace when picked", async () => {
+    const user = renderPage(<Pods />);
+    await screen.findByText("web-abc");
+
+    await user.selectOptions(screen.getByRole("combobox"), "prod");
+    await waitFor(() => expect(listPods).toHaveBeenCalledWith("prod"));
+  });
+
+  it("opens the pod it was told to, with its namespace", async () => {
+    // A pod is identified by both. Opening on the name alone would find
+    // the wrong pod wherever a name repeats across namespaces.
+    getPod.mockImplementation(() => new Promise(() => {}));
+    const user = renderPage(<Pods />);
+    await user.click(await screen.findByText("web-abc"));
+
+    await waitFor(() => expect(getPod).toHaveBeenCalledWith("prod", "web-abc"));
+  });
+
+  it("says so when nothing is visible", async () => {
+    listPods.mockResolvedValue([]);
+    renderPage(<Pods />);
+    expect(await screen.findByText("No pods visible.")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Two things, in three commits: raise test coverage, then audit the repository and wire up the scanners so the audit does not have to be repeated by hand.

## Coverage

| | Before | After |
| --- | --- | --- |
| Rust (lines) | 46.6% | **69.7%** |
| Frontend (statements) | 44.5% | **95.8%** |
| Tests | 177 | **420** |

**The Rust gap was not missing logic, it was logic welded to a network call.** `get_pod`, `get_object`, `get_node`, `get_namespace`, `get_release`, `apply_yaml` and the two data readers each fetched and then transformed in one function, so the only way to exercise the transformation was against a live cluster. The ignored cluster tests did exactly that, honestly, and CI ran none of them.

Each now has its transformation split out and tested directly — `pod_detail_from`, `object_detail_from`, `node_detail_from`, `namespace_detail_from`, `release_detail_from`, `prepare`, `config_map_data`, `secret_data`. The IO functions keep their names and behaviour; they fetch and delegate.

The tests carrying the most weight are the ones covering decisions that are hard to notice going wrong:

- A Secret reached through the **generic** detail path is redacted and non-editable. That path is the one an operator actually takes, and a redaction living only in a Secret-specific route would leave it printing credentials.
- `secret_data` discloses only the keys named in `reveal` — including when the name matches nothing, where there must be no fallback to "reveal all".
- The redaction placeholder does not vary with the value it replaces, so it cannot leak a password's length.
- `prepare` refuses a rename or a namespace move before anything is sent. Kubernetes has no rename; a changed name overwrites whichever bystander holds it.
- 409 is a conflict and 403 is not, so an RBAC denial never gets offered the editor's "reload and re-apply" path.
- Node allocation is measured against allocatable, not capacity.
- A namespace's phase tally always sums to the count printed beside it.

On the frontend, `src/pages` was at 12.9% and `App.tsx` at 0% — everything a user clicks was untested. Now covered, with the same bias toward consequential behaviour: DataView asks for no Secret values on open and stops asking once one is hidden; LogViewer stops its stream on unmount and before starting another (a followed stream is an open connection to the API server); App clears the query cache on connect and disconnect so rows from the previous cluster cannot appear under the new one's name.

**`api.test.ts` adds a check that had no equivalent before.** The command names are strings in `api.ts` and function names in `lib.rs`, and nothing in either compiler connects them — a rename leaves the frontend calling a command that does not exist, and it fails at runtime with no obvious cause. It now reads both files and compares the sets in both directions. Verified by renaming one and watching both directions fail.

## Security

Ran Semgrep, `cargo audit` and `pnpm audit`, fixed the findings, then added the workflows.

**Shell and script injection in the release workflow.** `inputs.tag` from `workflow_dispatch` was interpolated straight into a `run:` block and an `actions/github-script` body. `${{ }}` expands before the shell or the JS parser sees the text, so a tag containing a quote and a semicolon is not a mis-parsed string — it is a second command, running in the job that holds `TAP_TOKEN`, the Codecov token and (soon) the Apple signing secrets. Only people with write access can dispatch a workflow, but that is a larger set than the people trusted with those secrets. All three sites now pass through `env:`, as does `secrets.APPLE_CERTIFICATE`, which was being pasted into a shell script.

**Unused `opener` capability.** `tauri-plugin-opener` came with the scaffold, was registered, and was granted `opener:default` — while nothing in the frontend ever called it. It lets the webview ask the OS to open an arbitrary URL or path, and Loupe renders strings that come from the cluster. Removed from the crate, the npm package, the registration and the capability list.

**Dev origin in the production CSP.** `connect-src` carried `ws://localhost:1420` — the Vite HMR socket — in the policy that ships to users. Moved to `devCsp`.

**Actions pinned by mutable tag.** All 33 references now pin a commit SHA with the version in a trailing comment.

**Six npm advisories**, all in the test and build toolchain (vitest, its bundled vite, esbuild, postcss); none of it ships. Cleared by moving to vitest 3 and current postcss/autoprefixer — all 253 frontend tests pass on the new versions, which is the first thing the coverage work has been useful for.

`cargo audit` reports **no Rust vulnerabilities**. It reports 17 warnings, effectively all gtk-rs GTK3 bindings reached through Tauri's Linux backend: unmaintained, not vulnerable, and not ours to fix.

### Added

- `.github/dependabot.yml` — cargo, npm and actions, grouped so the output is reviewable, with a 7-day cooldown so a package published an hour ago is not pulled in an hour later.
- `.github/workflows/security.yml` — cargo-audit and pnpm audit, plus Semgrep on pinned OSS rulesets (not `--config auto`, which needs an account and reports findings to a service). Weekly, because advisories arrive on their own schedule and a repository that only scans on push stops being scanned once it stabilises.
- `.github/workflows/codeql.yml` — kept alongside Semgrep rather than instead of it. Semgrep matches patterns; CodeQL follows data, and "can a string from a cluster reach somewhere it is executed" is a dataflow question.

Both are **separate statuses from `ci`**, which stays the one to require in branch protection: an advisory published overnight should not block a docs fix. `cargo audit` runs without `--deny warnings` on purpose — the 17 unfixable warnings would make it permanently red, which is the same as not running it.

## Not done

`lib.rs` stays at 0%: it is Tauri command glue, and a test there would assert Tauri works rather than that Loupe does. The genuinely network-bound halves of `logs.rs`, `table.rs` and `mod.rs` are likewise still covered only by the `#[ignore]`d cluster tests.

Two things need repository settings I cannot change: **secret scanning with push protection**, and **CodeQL** may need "Advanced Setup" enabled under Settings → Code security before `codeql.yml` can upload results.
