### PR TITLE
Keep major dependency bumps out of the grouped PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,8 +26,11 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      # Tauri's crates move together and only work together; splitting
-      # them produces PRs that cannot build on their own.
+      # These two keep their majors grouped, unlike the npm tooling
+      # group below. Tauri's crates move together and only work
+      # together, and so do kube and k8s-openapi; splitting either
+      # produces PRs that cannot build on their own. The coupling is
+      # real here, where in the tooling group it was only alphabetical.
       tauri:
         patterns:
           - "tauri*"
@@ -52,13 +55,31 @@ updates:
       default-days: 7
     groups:
       react:
+        update-types:
+          - minor
+          - patch
         patterns:
           - "react"
           - "react-dom"
           - "@types/react*"
       # The test and build toolchain. Every advisory this repository has
       # had so far came from here, and none of it ships in the app.
+      #
+      # Minor and patch only, deliberately. Grouped majors produced one
+      # PR carrying TypeScript 5->7, Tailwind 3->4, Vite 7->8 and Vitest
+      # 3->4 together, which could only be merged or closed as a unit —
+      # and Tailwind 4 alone is a migration (its PostCSS plugin moved to
+      # `@tailwindcss/postcss` and the config format changed), so the
+      # unit was always going to be "closed". The five bumps that were
+      # fine went with it.
+      #
+      # A package whose major does not match this group falls outside
+      # every group and gets its own PR, which is what a migration
+      # wants: one at a time, reviewed on its own terms.
       tooling:
+        update-types:
+          - minor
+          - patch
         patterns:
           - "vite*"
           - "@vitejs/*"


### PR DESCRIPTION
Follow-up to #9, which was closed.

That PR bundled **four independent major migrations** into one unit: TypeScript 5→7, Tailwind 3→4, Vite 7→8 and Vitest 3→4. A grouped Dependabot PR can only be merged or closed as a whole, and Tailwind 4 alone is a migration rather than a bump — its PostCSS plugin moved to `@tailwindcss/postcss` and the config format changed, which is what failed the build:

> It looks like you're trying to use `tailwindcss` directly as a PostCSS plugin.

So the unit was always going to be closed, and the five bumps that were fine went with it. Closing #9 on its own does not prevent a repeat: the next time any of those six packages publishes, Dependabot re-groups the majors and proposes the same thing again.

## The change

`tooling` and `react` are now `minor` + `patch` only. A package whose **major** matches no group falls outside every group and gets its own PR — which is what a migration wants: one at a time, reviewed on its own terms.

The cargo groups deliberately keep their majors grouped, and the comment now says why rather than leaving the asymmetry to look like an oversight. Tauri's crates only work together, as do `kube` and `k8s-openapi`; splitting either produces PRs that cannot build on their own. That coupling is real, where in the `tooling` group it was only alphabetical.

Everything else major already falls out on its own — which is how `base64` 0.22→0.23 arrived as its own reviewable PR (#8, green).

## Resulting shape

| Ecosystem | Group | Majors |
| --- | --- | --- |
| cargo | `tauri`, `kubernetes` | grouped — genuinely coupled |
| cargo | `minor-and-patch` | own PR |
| npm | `react`, `tooling` | own PR |
| actions | `actions` | grouped — isolated, and #10 shows it works |

Config-only; no dependency versions move here.
