### PR TITLE
Do not require a sign-off on merge commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,22 @@ jobs:
               # (co-authored work), so warn rather than fail.
               echo "::warning::$(git show -s --format='%h' "$sha") sign-off does not match the author ($author)"
             fi
-          done < <(git rev-list "$BASE..$HEAD")
+          # `--no-merges` deliberately.
+          #
+          # A merge commit contributes no code: the contribution lives in
+          # the commits it joins, and every one of those is checked here.
+          # GitHub's "Update branch" button and its merge queue both
+          # create merge commits attributed to whoever pressed the
+          # button, with no sign-off — so requiring one turns a
+          # one-click branch refresh into a permanently red DCO that can
+          # only be cleared by rebasing and force-pushing. That happened
+          # twice in one afternoon, including on a Dependabot PR whose
+          # own commit was correctly signed off.
+          #
+          # This matches the DCO GitHub App, and the DCO itself: it is a
+          # statement about authoring a contribution, not about
+          # integrating one.
+          done < <(git rev-list --no-merges "$BASE..$HEAD")
 
           if [ "$missing" -ne 0 ]; then
             echo


### PR DESCRIPTION
Two PRs went red on DCO today (#11 and #8), and neither had anything wrong with the contribution.

## What happens

Branch protection here requires branches to be up to date before merging. When a PR falls behind, GitHub offers an **"Update branch"** button — which creates a merge commit attributed to whoever pressed it, with no `Signed-off-by`. The DCO check walked every commit including merges, so pressing that button put the PR into a state the button itself could not fix. The only way out was a local rebase and a force-push.

On #8 this landed on a **Dependabot** PR whose own commit was correctly signed off:

```
1165cf9  Merge branch 'main' into dependabot/…   ← no sign-off, authored by the button-presser
9519a9a  build(deps): Bump base64 0.22.1 → 0.23.0  ← Signed-off-by: dependabot[bot] ✓
```

So the failure was entirely an artefact of refreshing the branch, on a PR nobody hand-wrote.

## The change

One flag: `git rev-list --no-merges`.

A merge commit contributes no code. The contribution lives in the commits it joins, and every one of those is still checked — the guarantee is unchanged.

## Verified both directions

Against the real commits on #8:

```
=== before (merges included) ===
  MISSING 1165cf9 Merge branch 'main' into dependabot/…
  ok      9519a9a build(deps): Bump base64 from 0.22.1 to 0.23.0

=== after (--no-merges) ===
  ok      9519a9a build(deps): Bump base64 from 0.22.1 to 0.23.0
```

And it still catches real omissions — an unsigned ordinary commit is reported and still fails the job.

This matches what the [DCO GitHub App](https://github.com/apps/dco) does, and follows from what the DCO says: it is a statement about *authoring* a contribution, not about integrating one.

## Note on merging this one

Since this PR is itself subject to the current rule, use **Rebase** or plain merge rather than the "Update branch" button if it falls behind — otherwise it hits the very bug it fixes.
