### PR TITLE
release: 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loupe",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2195,7 +2195,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loupe"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64 0.23.0",
  "flate2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loupe"
-version = "0.1.0"
+version = "0.1.1"
 description = "An open-source desktop client for Kubernetes"
 authors = ["The Loupe Authors"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Loupe",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "ai.krypton.loupe",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump only. Merge this, then `v0.1.1` gets tagged on main to trigger the release build.

## What's in 0.1.1

Hardening. **Nothing user-facing changed since 0.1.0** — the detail views, CRD browsing, Helm and the theme picker all shipped there. Everything since has been test coverage, the security pass, and CI work.

Three changes reach the shipped binary:

- **The unused `opener` capability is gone.** It came with the Tauri scaffold and was never called, while granting the webview permission to ask the OS to open an arbitrary URL or path. That matters here because Loupe renders strings that come from the cluster — annotations, chart homepages, CRD fields.
- **Production CSP tightened.** `connect-src` was carrying `ws://localhost:1420`, the Vite HMR socket, in the policy shipped to users. Moved to `devCsp`.
- **`base64` 0.22.1 → 0.23.0** in the Rust binary.

## Still not signed

No Apple secrets are configured, so this is ad-hoc signed like 0.1.0 and first launch on macOS needs the same **System Settings → Privacy & Security → Open Anyway**. The cask's `caveats` block stays accurate.

## Checked locally

`cargo fmt`, `clippy -D warnings`, 167 Rust tests, 253 frontend tests, and `pnpm build` all pass at 0.1.1. All three manifests agree, which is what the release workflow's `version` job enforces against the tag.
