### PR TITLE
release: 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loupe",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2195,7 +2195,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loupe"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64 0.23.0",
  "flate2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loupe"
-version = "0.1.1"
+version = "0.1.2"
 description = "An open-source desktop client for Kubernetes"
 authors = ["The Loupe Authors"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Loupe",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "ai.krypton.loupe",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump only. Merge this, then `v0.1.2` gets tagged on main.

## What's in 0.1.2

**No code changes since 0.1.1.** The difference is entirely in how the macOS builds are signed: all six Apple secrets are now configured, so the release workflow takes the certificate path rather than falling back to ad-hoc signing.

If it works, this is the first release that **opens on a double-click** — no "Open Anyway" in System Settings, no `--no-quarantine`. That is a genuinely user-facing change, which the 0.1.1 hardening release wasn't.

## The signed path has never run

v0.1.0 was ad-hoc signed. This is the first time the certificate branch of the workflow executes, so treat it as unproven until the artifacts are checked.

Failure is contained: `publish` requires all four platform builds to succeed, so if notarisation fails there is no public release and no change to the Homebrew tap — just a draft to delete.

## The cask keeps its caveats

Deliberately. `packaging/homebrew/loupe.rb.template` still tells users how to get past Gatekeeper, and the tap job renders it in the same run that publishes — so there's no window to verify notarisation before the cask ships.

The asymmetry decides it: caveats present on a notarised build tell people to do something unnecessary, which is mildly confusing. Caveats absent on a build that *isn't* notarised leaves them stuck with no guidance. Keep them, verify the artifact, remove them in a follow-up.

## Checked locally

`cargo fmt`, `clippy -D warnings`, 167 Rust tests, 253 frontend tests and `pnpm build` all pass at 0.1.2, and the three manifests agree.
