### PR TITLE
Releases are notarised now — update the docs that say otherwise

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,8 @@ and the error is surfaced rather than swallowed into an empty table.
 brew install --cask kryptonhq/tap/loupe
 ```
 
-Loupe is not notarised by Apple yet, so macOS blocks the first launch.
-Allow it once under **System Settings → Privacy & Security → Open
-Anyway**, or install with `--no-quarantine`.
+The macOS builds are signed with a Developer ID and notarised, so the
+app opens on a double-click — nothing to allow in System Settings.
 
 Or take a build from [releases](https://github.com/kryptonhq/loupe/releases):
 
@@ -123,6 +122,10 @@ Or take a build from [releases](https://github.com/kryptonhq/loupe/releases):
 | macOS (Intel) | `Loupe_<version>_x64.dmg` |
 | Linux | `.AppImage` (portable) or `.deb` |
 | Windows | `-setup.exe` or `.msi` |
+
+The Windows installers are not signed yet, so SmartScreen will warn on
+first run — choose **More info → Run anyway**. Signing them is on the
+list; see [RELEASING.md](RELEASING.md#windows).
 
 Loupe reads the same kubeconfig as `kubectl`, so there is nothing to
 configure — it lists the contexts you already have.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -59,24 +59,27 @@ damaged and can't be opened. You should move it to the Trash."** That
 message is actively misleading: it points at a corrupt download rather
 than at an unsigned app, and there is no obvious way past it.
 
-**Ad-hoc signed**, which is what the release workflow does when no
-certificate is configured, the bundle carries a valid signature and the
-hardened runtime. Gatekeeper still refuses it — there is no
+**Ad-hoc signed**, which is what the release workflow falls back to when
+no certificate is configured, the bundle carries a valid signature and
+the hardened runtime. Gatekeeper still refuses it — there is no
 notarisation — but for the reason it actually is, and the user gets the
-normal "Open Anyway" path in Privacy & Security. This costs nothing and
-is the current default.
+normal "Open Anyway" path in Privacy & Security. This costs nothing.
+v0.1.0 and v0.1.1 shipped in this state.
 
 **Signed and notarised** is the only state where the app opens on a
 double-click, and the only one homebrew/cask would accept, since a cask
 there
 [must not require Gatekeeper to be bypassed](https://docs.brew.sh/Acceptable-Casks).
-Our own tap has no such rule, so the cask ships today with a `caveats`
-block that explains the situation rather than a `postflight` that strips
-the quarantine attribute silently.
+**This is where releases are from v0.1.2 onward.** `spctl` reports
+`accepted` with `source=Notarized Developer ID`, and the ticket is
+stapled, so approval does not depend on the machine being able to reach
+Apple.
 
 Getting there needs an Apple Developer account (99 USD/year) and these
 repository secrets. They are all-or-nothing: a partial set makes Tauri
-attempt a notarisation it cannot complete.
+attempt a notarisation it cannot complete — and because an unset secret
+is still a *defined* environment variable, a partial set fails after
+building all four platforms rather than in the first ten seconds.
 
 | Secret | What it is |
 | --- | --- |
@@ -154,9 +157,33 @@ variables therefore only exist when there is a certificate.
 
 Unsigned installers work, but SmartScreen warns until the binary has
 built up reputation — which for a low-volume download effectively means
-always. Signing needs a code-signing certificate and a
-`bundle.windows.signCommand` in `tauri.conf.json`; there is no
-credential-only path.
+always. Worse on Windows 11, where Smart App Control blocks unsigned
+executables outright rather than offering a way through.
+
+Signing needs a certificate and a `bundle.windows.signCommand` in
+`tauri.conf.json`. Nothing here is set up yet; the options, cheapest
+first:
+
+| Option | Cost | Hardware token |
+| --- | --- | --- |
+| [SignPath Foundation](https://signpath.org/) | free for OSS | no |
+| [Certum Open Source](https://shop.certum.eu/code-signing.html) | ~€69 first year, ~€29 after | yes |
+| [Azure Artifact Signing](https://azure.microsoft.com/en-us/products/artifact-signing) | ~$10/month | no |
+
+Do not pay for EV. Microsoft
+[removed the behaviour](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/smartscreen-reputation)
+that made an EV certificate grant instant SmartScreen reputation, so it
+now behaves exactly like OV and costs several times more.
+
+Note that signing does not remove the warning the way notarisation does
+on macOS. It attaches a publisher name to it and lets reputation
+accumulate across releases, which unsigned builds cannot do at all —
+every new binary starts from zero.
+
+SignPath is the one to try first, since Loupe qualifies on licence and
+repository. Its condition worth knowing in advance is that each release
+needs manual approval before signing, which the current tag-triggered
+pipeline does not have a step for.
 
 ## Homebrew
 
@@ -164,16 +191,17 @@ credential-only path.
 brew install --cask kryptonhq/tap/loupe
 ```
 
-Until the builds are notarised, first launch needs one of:
+From v0.1.2 the builds are notarised, so this installs an app that
+opens on a double-click. No `--no-quarantine`, and nothing to allow in
+System Settings.
 
-- **System Settings → Privacy & Security → Open Anyway**, or
-- `brew install --cask --no-quarantine kryptonhq/tap/loupe`
-
-The cask says so in its caveats. It could remove the quarantine
-attribute itself in a `postflight` and make the whole thing invisible,
-and deliberately does not: stripping a security attribute on someone's
-behalf, without them asking, is not a decision an installer should make
-quietly.
+The cask carried a `caveats` block explaining how to get past Gatekeeper
+for as long as that was true, and it is gone now that it is not. It
+never grew the `postflight` that would have stripped the quarantine
+attribute silently: removing a security attribute on someone's behalf,
+without them asking, is not a decision an installer should make quietly
+— and the fix for "Gatekeeper refuses this" was always to earn its
+approval rather than to route around it.
 
 ### The tap
 
@@ -236,38 +264,47 @@ before the tap exists.
 Checksums are taken from the uploaded artifacts rather than from a local
 build, so what the cask claims is what people actually download.
 
-## The first signed release
+## Checking a signed release
 
-The signed path has never run, and the first release showed what an
-untested path costs. When the certificate is in place, prove it on a tag
-nobody is watching:
-
-```bash
-git tag v0.0.2-test && git push origin v0.0.2-test
-```
-
-Check the resulting draft, then throw both away:
+Run this against a published DMG whenever the signing configuration
+changes — a renewed certificate, a rotated app-specific password, a
+Tauri upgrade that moves the notarisation step.
 
 ```bash
-gh release delete v0.0.2-test --repo kryptonhq/loupe --yes
-git push --delete origin v0.0.2-test
+gh release download vX.Y.Z --repo kryptonhq/loupe --pattern '*aarch64.dmg'
+hdiutil attach -nobrowse Loupe_X.Y.Z_aarch64.dmg -mountpoint /tmp/loupe
+
+# Authority should name the Developer ID, and the flags should say
+# "runtime" — an "adhoc" in either means the certificate path did not run.
+codesign -dv --verbose=2 /tmp/loupe/Loupe.app
+# The verdict that matters. Want: accepted, source=Notarized Developer ID.
+spctl -a -vvv /tmp/loupe/Loupe.app
+# The ticket is stapled, so approval does not need to reach Apple.
+xcrun stapler validate /tmp/loupe/Loupe.app
+
+hdiutil detach /tmp/loupe
 ```
 
-What to look for on the built app:
+Do both architectures. They are separate builds and notarised
+separately, so one can succeed while the other does not.
 
-```bash
-# Authority should name the Developer ID, not "adhoc".
-codesign -dv --verbose=2 /Applications/Loupe.app
-# The verdict that matters — "accepted" means Gatekeeper is satisfied.
-spctl -a -vvv /Applications/Loupe.app
-# And the notarisation ticket is stapled, so it works offline.
-xcrun stapler validate /Applications/Loupe.app
-```
+### Testing on a throwaway tag does not work yet
 
-Once `spctl` says accepted, the `caveats` block in
-[the cask template](packaging/homebrew/loupe.rb.template) is obsolete
-and should be removed — it tells users to work around a problem they no
-longer have.
+The obvious way to rehearse a change would be a tag nobody is watching,
+and there is no supported way to do that today. Two things are in the
+way, and both are worth fixing before anyone needs it:
+
+- The `version` job requires the manifests to match the tag, and
+  `scripts/version.py --set` only accepts plain `X.Y.Z` — so a
+  pre-release tag like `v0.0.2-test` cannot be made to pass.
+- Nothing excludes a test tag from `publish` or `homebrew`. A run that
+  *succeeded* would publish a public release and repoint the tap's cask
+  at the test version, breaking `brew install` for everyone.
+
+So changes to the signing path currently get proven by cutting a real
+release and relying on the containment that already exists: `publish`
+needs all four builds to succeed, so a notarisation failure leaves a
+draft and an untouched tap rather than anything public.
 
 ## Not done yet
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -87,10 +87,58 @@ attempt a notarisation it cannot complete.
 | `APPLE_PASSWORD` | An app-specific password, not the account password |
 | `APPLE_TEAM_ID` | The 10-character team identifier |
 
-```bash
-# Export the certificate from Keychain Access first.
-base64 -i DeveloperID.p12 | pbcopy
-```
+#### Getting them
+
+The fiddly part is the export: the obvious path in Keychain Access
+produces a certificate **without its private key**, which signs nothing
+and fails with an error that does not say so.
+
+1. **Make a signing request.** Keychain Access → Certificate Assistant →
+   *Request a Certificate From a Certificate Authority*. Enter your
+   email, choose **Saved to disk**, and keep the `.certSigningRequest`.
+
+2. **Create the certificate.** [developer.apple.com](https://developer.apple.com/account/resources/certificates/list)
+   → Certificates → **+** → **Developer ID Application** (not "Apple
+   Distribution", which is the App Store one). Upload the request,
+   download the `.cer`, and double-click it to install.
+
+3. **Export it *with* the key.** In Keychain Access, open **My
+   Certificates** — not the Certificates category — and find
+   `Developer ID Application: <name> (TEAMID)`. It must have a
+   disclosure triangle with a private key under it. Right-click →
+   *Export* → `.p12`, and set a password.
+
+   If it is not under My Certificates, the private key is on whichever
+   Mac generated the request in step 1.
+
+4. **Encode it.**
+
+   ```bash
+   base64 -i DeveloperID.p12 | pbcopy      # -> APPLE_CERTIFICATE
+   ```
+
+   The password you just set is `APPLE_CERTIFICATE_PASSWORD`.
+
+5. **Read the identity string exactly.** Copying it by eye from the
+   portal is how people end up with a trailing space:
+
+   ```bash
+   security find-identity -v -p codesigning   # -> APPLE_SIGNING_IDENTITY
+   ```
+
+6. **Team ID** is on the [membership page](https://developer.apple.com/account)
+   — ten characters, and also the parenthesised part of the identity
+   string above.
+
+7. **App-specific password** for notarisation, from
+   [appleid.apple.com](https://appleid.apple.com) → Sign-In and Security
+   → App-Specific Passwords. Not your Apple ID password, which will not
+   work.
+
+An App Store Connect API key is the more durable alternative to steps 6
+and 7 — it survives password rotations and 2FA changes, which an
+app-specific password does not. Worth switching to if the notarisation
+step starts failing after an account change.
 
 When they are all present Tauri signs with the real identity and
 notarises; otherwise it ad-hoc signs.
@@ -187,6 +235,39 @@ before the tap exists.
 
 Checksums are taken from the uploaded artifacts rather than from a local
 build, so what the cask claims is what people actually download.
+
+## The first signed release
+
+The signed path has never run, and the first release showed what an
+untested path costs. When the certificate is in place, prove it on a tag
+nobody is watching:
+
+```bash
+git tag v0.0.2-test && git push origin v0.0.2-test
+```
+
+Check the resulting draft, then throw both away:
+
+```bash
+gh release delete v0.0.2-test --repo kryptonhq/loupe --yes
+git push --delete origin v0.0.2-test
+```
+
+What to look for on the built app:
+
+```bash
+# Authority should name the Developer ID, not "adhoc".
+codesign -dv --verbose=2 /Applications/Loupe.app
+# The verdict that matters — "accepted" means Gatekeeper is satisfied.
+spctl -a -vvv /Applications/Loupe.app
+# And the notarisation ticket is stapled, so it works offline.
+xcrun stapler validate /Applications/Loupe.app
+```
+
+Once `spctl` says accepted, the `caveats` block in
+[the cask template](packaging/homebrew/loupe.rb.template) is obsolete
+and should be removed — it tells users to work around a problem they no
+longer have.
 
 ## Not done yet
 

--- a/packaging/homebrew/loupe.rb.template
+++ b/packaging/homebrew/loupe.rb.template
@@ -19,25 +19,20 @@ cask "loupe" do
 
   app "Loupe.app"
 
-  # Said plainly rather than worked around. Loupe is ad-hoc signed but
-  # not notarised, so Gatekeeper refuses it on first open. A cask can
-  # strip the quarantine attribute in a postflight and make that
-  # invisible — this one deliberately does not. Removing a security
-  # attribute on someone's behalf, without them asking, is not a
-  # decision an installer should make quietly.
-  caveats <<~EOS
-    Loupe is not yet notarised by Apple, so macOS will refuse to open it
-    the first time. Either allow it once:
-
-      System Settings -> Privacy & Security -> Open Anyway
-
-    or install without the quarantine attribute:
-
-      brew install --cask --no-quarantine #{token}
-
-    Notarised builds are planned; see
-    https://github.com/kryptonhq/loupe/blob/main/RELEASING.md
-  EOS
+  # No caveats, and no postflight.
+  #
+  # From v0.1.2 the macOS builds are signed with a Developer ID and
+  # notarised, with the ticket stapled — `spctl` reports "accepted,
+  # source=Notarized Developer ID" — so there is nothing for the user to
+  # allow and nothing to explain.
+  #
+  # Before that this cask carried a caveats block describing how to get
+  # past Gatekeeper. What it never carried was a postflight stripping
+  # the quarantine attribute, which would have hidden the problem
+  # instead of stating it: removing a security attribute on someone's
+  # behalf, without them asking, is not a decision an installer should
+  # make quietly. The fix for "Gatekeeper refuses this" was to earn its
+  # approval, not to route around it.
 
   # Everything Loupe writes, so `brew uninstall --zap` leaves nothing.
   # `settings.json` lives in the Application Support directory; the


### PR DESCRIPTION
Supersedes #6, whose commit is included here rather than rewritten.

v0.1.2 was the first release built through the certificate path, and it verifies as signed and notarised on **both** architectures:

```
Authority=Developer ID Application: Kruthiventi Naga Sai Varun (G48QQ5ZCAT)
Authority=Developer ID Certification Authority
Authority=Apple Root CA
flags=0x10000(runtime)          ← no adhoc

spctl:   accepted, source=Notarized Developer ID
stapler: The validate action worked!
```

So three places were telling users to work around a problem they no longer have.

## What changed

**The cask's `caveats` block is gone.** It explained how to get past Gatekeeper, which is now wrong. The comment about *why there is no `postflight`* stays, because that reasoning outlived the caveats and is the more useful half — stripping the quarantine attribute would have hidden the problem rather than fixing it, and the fix was to earn Gatekeeper's approval instead.

**README** no longer says the app is unnotarised. It also now mentions that **Windows** installers are unsigned and will trip SmartScreen — with the macOS caveat removed, staying silent would have implied every platform installs cleanly.

**RELEASING.md** describes ad-hoc as what v0.1.0 and v0.1.1 shipped, rather than as the current state.

## Two corrections beyond the notarisation state

**The Windows section was wrong.** It claimed there is "no credential-only path" for signing. [Azure Artifact Signing](https://azure.microsoft.com/en-us/products/artifact-signing) is exactly that, and [SignPath Foundation](https://signpath.org/) is free for open-source projects. The section now lists the real options with costs, and notes **not to pay for EV** — Microsoft [removed](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/smartscreen-reputation) the instant-SmartScreen-reputation behaviour that was the only reason to, so EV now behaves like OV at several times the price.

**The "test on a throwaway tag" recipe cannot work**, and is now documented as a known gap instead of left as a trap. We hit it directly: `v0.0.2-test` failed the version job, because the manifests must match the tag and `--set` only accepts plain `X.Y.Z`, so a pre-release tag can never pass.

Worse, and only found by reading the workflow afterwards: **nothing excludes a test tag from `publish` or `homebrew`.** A run that *succeeded* would have published a public release and repointed the tap's cask at the test version, breaking `brew install` for everyone. The guard failing was luck.

Replaced with the verification commands, which were the useful part — including the note to check both architectures, since they are notarised separately and one can succeed while the other does not.

## Note on when this reaches users

The tap's live cask still has the caveats; it is only re-rendered when a release publishes. So this takes effect at the next release, which is fine — the text is wrong but harmless, telling people to do something unnecessary rather than leaving them stuck.

Fixing the throwaway-tag gap properly (accept pre-release versions, skip `publish`/`homebrew` for them) is a workflow change I've left out of this docs PR.
