### PR TITLE
A shell that holds several things open at once

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,12 +10,13 @@ mod cluster;
 mod error;
 mod export;
 mod guard;
+mod menu;
 mod settings;
 mod vibrancy;
 
 use cluster::{ClusterInfo, ContextInfo, SharedSession};
 use error::Result;
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 
 #[tauri::command]
 fn list_contexts() -> Result<Vec<ContextInfo>> {
@@ -562,6 +563,19 @@ fn set_theme(app: tauri::AppHandle, theme: settings::Theme) -> Result<settings::
     Ok(current)
 }
 
+/// Records the interface scale and returns the settings as stored.
+///
+/// Clamped on the way in: the frontend steps through a fixed set of
+/// sizes, but the command is reachable on its own, and a window drawn at
+/// twenty times its size has no way back to the control that fixes it.
+#[tauri::command]
+fn set_zoom(app: tauri::AppHandle, zoom: f64) -> Result<settings::Settings> {
+    let mut current = settings::load(&app);
+    current.zoom = settings::clamp_zoom(zoom);
+    settings::save(&app, &current)?;
+    Ok(current)
+}
+
 /// Whether native window vibrancy is actually active.
 ///
 /// The frontend asks at startup rather than guessing from the platform:
@@ -595,7 +609,21 @@ pub fn run() {
         .setup(|app| {
             app.manage(SharedSession::default());
             app.manage(VibrancyState(vibrancy::setup(app)));
+            // Losing the menu is a poor outcome; refusing to start over
+            // it is a worse one.
+            if let Err(e) = menu::install(app.handle()) {
+                eprintln!("[loupe] could not install the menu: {e}");
+            }
             Ok(())
+        })
+        .on_menu_event(|app, event| {
+            // The menu says what was asked for; the frontend owns what
+            // the current scale is and what the next one up looks like,
+            // so this forwards rather than decides.
+            let id = event.id().as_ref();
+            if matches!(id, menu::ZOOM_IN | menu::ZOOM_OUT | menu::ZOOM_RESET) {
+                let _ = app.emit(menu::ZOOM_EVENT, id);
+            }
         })
         .invoke_handler(tauri::generate_handler![
             list_contexts,
@@ -644,6 +672,7 @@ pub fn run() {
             save_text,
             get_settings,
             set_theme,
+            set_zoom,
             set_context_pinned,
             context_guard,
             set_context_guard,

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1,0 +1,106 @@
+//! The application menu.
+//!
+//! Only installed on macOS, where a menu bar already exists and the app
+//! is currently living off Tauri's default one. Windows and Linux draw a
+//! menu inside the window, and adding one there would change the shape
+//! of a window nobody asked to change — the keyboard shortcuts work on
+//! every platform regardless, because the frontend binds them itself.
+//!
+//! Setting a menu replaces the default wholesale, so everything the
+//! default gave us has to be named again. That is why Edit is here: drop
+//! it and Cmd-C stops working, which is a spectacular way to break an
+//! app while adding a zoom control.
+
+#[cfg(target_os = "macos")]
+use tauri::{
+    menu::{AboutMetadata, Menu, MenuItem, PredefinedMenuItem, Submenu},
+    Runtime,
+};
+
+/// Menu ids the frontend acts on. Kept as constants because they are a
+/// contract with `App.tsx`, not incidental strings.
+pub const ZOOM_IN: &str = "zoom-in";
+pub const ZOOM_OUT: &str = "zoom-out";
+pub const ZOOM_RESET: &str = "zoom-reset";
+
+/// The event the menu emits, carrying one of the ids above.
+pub const ZOOM_EVENT: &str = "menu:zoom";
+
+/// Build and install the menu.
+///
+/// Fallible, and deliberately not fatal at the call site: an accelerator
+/// this build of Tauri will not parse should cost the user a menu, not a
+/// window.
+#[cfg(target_os = "macos")]
+pub fn install<R: Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
+    let zoom_in = MenuItem::with_id(app, ZOOM_IN, "Zoom In", true, Some("CmdOrCtrl+="))?;
+    let zoom_out = MenuItem::with_id(app, ZOOM_OUT, "Zoom Out", true, Some("CmdOrCtrl+-"))?;
+    let zoom_reset = MenuItem::with_id(app, ZOOM_RESET, "Actual Size", true, Some("CmdOrCtrl+0"))?;
+
+    let app_menu = Submenu::with_items(
+        app,
+        "Loupe",
+        true,
+        &[
+            &PredefinedMenuItem::about(app, None, Some(AboutMetadata::default()))?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::services(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::hide(app, None)?,
+            &PredefinedMenuItem::hide_others(app, None)?,
+            &PredefinedMenuItem::show_all(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::quit(app, None)?,
+        ],
+    )?;
+
+    // Not decoration. The webview's own copy and paste come from here.
+    let edit = Submenu::with_items(
+        app,
+        "Edit",
+        true,
+        &[
+            &PredefinedMenuItem::undo(app, None)?,
+            &PredefinedMenuItem::redo(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::cut(app, None)?,
+            &PredefinedMenuItem::copy(app, None)?,
+            &PredefinedMenuItem::paste(app, None)?,
+            &PredefinedMenuItem::select_all(app, None)?,
+        ],
+    )?;
+
+    let view = Submenu::with_items(
+        app,
+        "View",
+        true,
+        &[
+            &zoom_in,
+            &zoom_out,
+            &zoom_reset,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::fullscreen(app, None)?,
+        ],
+    )?;
+
+    let window = Submenu::with_items(
+        app,
+        "Window",
+        true,
+        &[
+            &PredefinedMenuItem::minimize(app, None)?,
+            &PredefinedMenuItem::maximize(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::close_window(app, None)?,
+        ],
+    )?;
+
+    let menu = Menu::with_items(app, &[&app_menu, &edit, &view, &window])?;
+    app.set_menu(menu)?;
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn install<R: tauri::Runtime>(_app: &tauri::AppHandle<R>) -> tauri::Result<()> {
+    Ok(())
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -36,7 +36,7 @@ pub enum Theme {
 /// second copy of the kubeconfig.
 const MAX_RECENT: usize = 8;
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct Settings {
     pub theme: Theme,
@@ -61,6 +61,48 @@ pub struct Settings {
     /// Glob patterns marking contexts protected without naming each one
     /// — `*prod*` covers six hundred clusters in one line.
     pub protected_patterns: Vec<String>,
+
+    /// Interface scale, where 1.0 is the size the app is drawn at.
+    ///
+    /// An accessibility setting, so it is stored rather than reset each
+    /// launch: someone who needs 150% needs it every time, and having to
+    /// say so at every start is the same as not having the control.
+    #[serde(default = "default_zoom")]
+    pub zoom: f64,
+}
+
+/// Serde needs a function for a non-zero default, and `Default` for the
+/// struct as a whole has to agree with it.
+fn default_zoom() -> f64 {
+    1.0
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            theme: Theme::default(),
+            recent_contexts: Vec::new(),
+            pinned_contexts: Vec::new(),
+            read_only_contexts: Vec::new(),
+            protected_contexts: Vec::new(),
+            protected_patterns: Vec::new(),
+            zoom: default_zoom(),
+        }
+    }
+}
+
+/// What the app will render at. Anything outside this is a settings file
+/// that has been edited by hand, and is clamped rather than obeyed — a
+/// window drawn at 20x has no way back to the control that fixes it.
+const MIN_ZOOM: f64 = 0.75;
+const MAX_ZOOM: f64 = 2.0;
+
+/// Bring a stored or requested scale into range.
+pub fn clamp_zoom(zoom: f64) -> f64 {
+    if !zoom.is_finite() {
+        return 1.0;
+    }
+    zoom.clamp(MIN_ZOOM, MAX_ZOOM)
 }
 
 impl Settings {
@@ -191,6 +233,36 @@ mod tests {
         assert_eq!(json["theme"], "dark");
         assert_eq!(json["recentContexts"], serde_json::json!([]));
         assert_eq!(json["pinnedContexts"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn zoom_defaults_to_the_size_the_app_is_drawn_at() {
+        assert_eq!(Settings::default().zoom, 1.0);
+        assert_eq!(
+            serde_json::to_value(Settings::default()).unwrap()["zoom"],
+            1.0
+        );
+    }
+
+    #[test]
+    fn a_settings_file_written_before_zoom_existed_reads_at_full_size() {
+        // Rather than at 0, which is what a bare numeric default would
+        // give and which would render the window to nothing.
+        let settings: Settings = serde_json::from_str(r#"{"theme":"dark"}"#).unwrap();
+        assert_eq!(settings.zoom, 1.0);
+    }
+
+    #[test]
+    fn a_hand_edited_zoom_is_clamped_rather_than_obeyed() {
+        // A window drawn at twenty times its size has no way back to the
+        // control that would fix it.
+        assert_eq!(clamp_zoom(20.0), 2.0);
+        assert_eq!(clamp_zoom(0.01), 0.75);
+        assert_eq!(clamp_zoom(-1.0), 0.75);
+        assert_eq!(clamp_zoom(f64::NAN), 1.0);
+        assert_eq!(clamp_zoom(f64::INFINITY), 1.0);
+        // And a sane one is left alone.
+        assert_eq!(clamp_zoom(1.25), 1.25);
     }
 
     #[test]

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -204,16 +204,19 @@ describe("App navigation", () => {
 // object keeps the listing it came from, that back retraces the trip,
 // and that a tab is a piece of work you can leave and return to.
 describe("App workspace", () => {
-  it("keeps the listing behind an object it opened", async () => {
+  it("says where an object sits, not how it was reached", async () => {
+    // Reached by way of Nodes, but a pod does not live under Nodes. The
+    // crumbs are derived from the pod itself: its listing, its
+    // namespace, its name. Where you have been is the arrows' job.
     const user = renderApp();
     await screen.findByRole("heading", { name: "Nodes" });
 
     await openPod(user);
 
-    // The trail says where this came from, which is the whole difference
-    // between a tab and a page that replaced another.
-    const trail = screen.getByRole("navigation", { name: "Trail" });
-    expect(within(trail).getByTitle(/Back to Pods/)).toBeInTheDocument();
+    const crumbs = screen.getByRole("navigation", { name: "Breadcrumb" });
+    expect(within(crumbs).getByTitle(/Go to Pods/)).toBeInTheDocument();
+    expect(within(crumbs).getByTitle(/Go to Namespace prod/)).toBeInTheDocument();
+    expect(within(crumbs).queryByTitle(/Nodes/)).not.toBeInTheDocument();
   });
 
   it("goes back to the listing and forward to the object again", async () => {
@@ -239,22 +242,22 @@ describe("App workspace", () => {
     expect(await screen.findByRole("heading", { name: "Pods" })).toBeInTheDocument();
   });
 
-  it("walks back several steps from a crumb", async () => {
+  it("goes to the listing an object belongs to from its crumb", async () => {
     const user = renderApp();
     await screen.findByRole("heading", { name: "Nodes" });
     await openPod(user);
 
-    const trail = screen.getByRole("navigation", { name: "Trail" });
-    await user.click(within(trail).getByTitle(/Back to Nodes/));
+    const crumbs = screen.getByRole("navigation", { name: "Breadcrumb" });
+    await user.click(within(crumbs).getByTitle(/Go to Pods/));
 
-    expect(await screen.findByRole("heading", { name: "Nodes" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Pods" })).toBeInTheDocument();
   });
 
-  it("hides the trail at the top of a tab, where there is no path", async () => {
+  it("hides the bar on a listing opened fresh, where it would only repeat the heading", async () => {
     renderApp();
     await screen.findByRole("heading", { name: "Nodes" });
     expect(
-      screen.queryByRole("navigation", { name: "Trail" }),
+      screen.queryByRole("navigation", { name: "Breadcrumb" }),
     ).not.toBeInTheDocument();
   });
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -31,6 +31,7 @@ vi.mock("./lib/api", async (original) => {
       currentCluster: vi.fn(),
       getSettings: vi.fn(),
       setTheme: vi.fn(),
+      setZoom: vi.fn(),
       disconnect: vi.fn(),
       listContexts: vi.fn(),
       connect: vi.fn(),
@@ -77,6 +78,7 @@ function renderApp() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  document.documentElement.style.removeProperty("zoom");
 
   // jsdom has no matchMedia, and the theme effect reads it on mount.
   Object.defineProperty(window, "matchMedia", {
@@ -90,8 +92,8 @@ beforeEach(() => {
   });
 
   currentCluster.mockResolvedValue(CLUSTER);
-  getSettings.mockResolvedValue({ theme: "system", recentContexts: [], pinnedContexts: [] });
-  setTheme.mockResolvedValue({ theme: "dark", recentContexts: [], pinnedContexts: [] });
+  getSettings.mockResolvedValue({ theme: "system", recentContexts: [], pinnedContexts: [], zoom: 1 });
+  setTheme.mockResolvedValue({ theme: "dark", recentContexts: [], pinnedContexts: [], zoom: 1 });
   disconnect.mockResolvedValue(undefined);
   listContexts.mockResolvedValue([
     {
@@ -114,6 +116,12 @@ beforeEach(() => {
   vi.mocked(api.listApiResources).mockResolvedValue([]);
   vi.mocked(api.listHelmReleases).mockResolvedValue([]);
   vi.mocked(api.vibrancyEnabled).mockResolvedValue(false);
+  vi.mocked(api.setZoom).mockResolvedValue({
+    theme: "system",
+    recentContexts: [],
+    pinnedContexts: [],
+    zoom: 1,
+  });
   vi.mocked(api.listEvents).mockResolvedValue([]);
   vi.mocked(api.listRelated).mockResolvedValue([]);
   vi.mocked(api.listPods).mockResolvedValue([
@@ -638,6 +646,80 @@ describe("App command palette", () => {
   });
 });
 
+// Zoom is an accessibility control: 13px is too small for a good number
+// of people to read for an hour, and the alternative is resizing every
+// other window on the machine to fix one.
+describe("App zoom", () => {
+  it("scales the interface, and steps back to normal", async () => {
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+
+    await user.keyboard("{Meta>}={/Meta}");
+    await waitFor(() =>
+      expect(document.documentElement.style.zoom).toBe("1.1"),
+    );
+
+    await user.keyboard("{Meta>}0{/Meta}");
+    // Removed rather than set to 1, so the ordinary case leaves no trace.
+    await waitFor(() => expect(document.documentElement.style.zoom).toBe(""));
+  });
+
+  it("shrinks as well as grows", async () => {
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+
+    await user.keyboard("{Meta>}-{/Meta}");
+    await waitFor(() => expect(document.documentElement.style.zoom).toBe("0.9"));
+  });
+
+  it("remembers the size across launches", async () => {
+    // Someone who needs 150% needs it every time. Having to say so at
+    // every start is the same as not having the control.
+    getSettings.mockResolvedValue({
+      theme: "system",
+      recentContexts: [],
+      pinnedContexts: [],
+      zoom: 1.5,
+    });
+    renderApp();
+    await waitFor(() => expect(document.documentElement.style.zoom).toBe("1.5"));
+  });
+
+  it("persists a size the moment it changes", async () => {
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+
+    await user.keyboard("{Meta>}={/Meta}");
+    await waitFor(() => expect(api.setZoom).toHaveBeenCalledWith(1.1));
+  });
+
+  it("applies a size that failed to persist anyway", async () => {
+    // Same rule as the theme: the keystroke should land, and a size that
+    // could not be written is still the one that was asked for.
+    vi.mocked(api.setZoom).mockRejectedValue(new Error("disk full"));
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+
+    await user.keyboard("{Meta>}={/Meta}");
+    await waitFor(() =>
+      expect(document.documentElement.style.zoom).toBe("1.1"),
+    );
+  });
+
+  it("ignores a stored size it cannot make sense of", async () => {
+    getSettings.mockResolvedValue({
+      theme: "system",
+      recentContexts: [],
+      pinnedContexts: [],
+      zoom: 40,
+    });
+    renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+    // Clamped to the largest step the layout has been looked at in.
+    await waitFor(() => expect(document.documentElement.style.zoom).toBe("2"));
+  });
+});
+
 describe("App theme", () => {
   it("persists a chosen theme", async () => {
     const user = renderApp();
@@ -660,7 +742,7 @@ describe("App theme", () => {
   });
 
   it("honours a stored preference on launch", async () => {
-    getSettings.mockResolvedValue({ theme: "dark", recentContexts: [], pinnedContexts: [] });
+    getSettings.mockResolvedValue({ theme: "dark", recentContexts: [], pinnedContexts: [], zoom: 1 });
     renderApp();
     await waitFor(() => expect(document.documentElement).toHaveClass("dark"));
   });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -107,7 +107,9 @@ beforeEach(() => {
   listNodes.mockResolvedValue([
     { name: "worker-1", ready: true, roles: [], version: "v1.33.1", age: "1d" },
   ]);
-  vi.mocked(api.listNamespaces).mockResolvedValue([]);
+  vi.mocked(api.listNamespaces).mockResolvedValue([
+    { name: "prod", phase: "Active", age: "120d" },
+  ]);
   vi.mocked(api.listPods).mockResolvedValue([]);
   vi.mocked(api.listApiResources).mockResolvedValue([]);
   vi.mocked(api.listHelmReleases).mockResolvedValue([]);
@@ -144,6 +146,11 @@ beforeEach(() => {
     yaml: "apiVersion: v1\nkind: Pod\n",
   });
 });
+
+/// The namespace picker, told apart from the status bar's guard picker.
+function namespacePicker() {
+  return screen.getByRole("combobox", { name: /Namespace/i });
+}
 
 /// Open the pod list, then the one pod in it.
 async function openPod(user: ReturnType<typeof userEvent.setup>) {
@@ -398,6 +405,64 @@ describe("App workspace", () => {
     expect(
       await screen.findByRole("heading", { name: "Deployments" }),
     ).toBeInTheDocument();
+  });
+
+  it("keeps the namespace filter across opening a pod and coming back", async () => {
+    // The filter used to live in the listing, and a listing unmounts the
+    // moment you open a row from it — so drilling into a pod and pressing
+    // back handed you every namespace again and a dropdown to re-pick.
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+
+    await user.click(screen.getByRole("button", { name: /Pods/ }));
+    await screen.findByText("web-abc");
+    await user.selectOptions(namespacePicker(), "prod");
+    await waitFor(() => expect(api.listPods).toHaveBeenCalledWith("prod"));
+
+    await user.click(await screen.findByText("web-abc"));
+    await screen.findByRole("heading", { name: "web-abc" });
+
+    await user.click(screen.getByRole("button", { name: "Back" }));
+
+    await screen.findByRole("heading", { name: "Pods" });
+    await waitFor(() =>
+      expect(namespacePicker()).toHaveValue("prod"),
+    );
+  });
+
+  it("keeps a filter change out of the history", async () => {
+    // Scoping a listing is the same destination shown differently. If it
+    // pushed, back would mean "undo my last keystroke" and walking out of
+    // a listing would take one press per filter you had tried.
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+
+    await user.click(screen.getByRole("button", { name: /Pods/ }));
+    await screen.findByText("web-abc");
+    await user.selectOptions(namespacePicker(), "prod");
+    await waitFor(() => expect(api.listPods).toHaveBeenCalledWith("prod"));
+
+    await user.click(screen.getByRole("button", { name: "Back" }));
+    expect(await screen.findByRole("heading", { name: "Nodes" })).toBeInTheDocument();
+  });
+
+  it("gives each tab its own filter", async () => {
+    // Two tabs on the same listing scoped to different namespaces is the
+    // point of a tab being a piece of work rather than a bookmark.
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+
+    await user.click(screen.getByRole("button", { name: /Pods/ }));
+    await screen.findByText("web-abc");
+    await user.selectOptions(namespacePicker(), "prod");
+    await waitFor(() => expect(namespacePicker()).toHaveValue("prod"));
+
+    await user.keyboard("{Meta>}t{/Meta}");
+    await screen.findByRole("heading", { name: "Pods" });
+    await user.selectOptions(namespacePicker(), "");
+
+    await user.keyboard("{Meta>}1{/Meta}");
+    await waitFor(() => expect(namespacePicker()).toHaveValue("prod"));
   });
 
   it("starts a fresh workspace when the cluster changes", async () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
@@ -14,8 +14,20 @@ vi.mock("./lib/api", async (original) => {
   const actual = await original<typeof import("./lib/api")>();
   return {
     ...actual,
+    // Listings hold a watch, and Tauri's own Channel reaches into webview
+    // internals that do not exist here.
+    Channel: class {
+      onmessage?: (event: unknown) => void;
+    },
     api: {
       ...actual.api,
+      startWatch: vi.fn().mockResolvedValue(1),
+      stopWatch: vi.fn().mockResolvedValue(true),
+      getPod: vi.fn(),
+      getObject: vi.fn(),
+      listRelated: vi.fn(),
+      listTable: vi.fn(),
+      listEvents: vi.fn(),
       currentCluster: vi.fn(),
       getSettings: vi.fn(),
       setTheme: vi.fn(),
@@ -100,7 +112,45 @@ beforeEach(() => {
   vi.mocked(api.listApiResources).mockResolvedValue([]);
   vi.mocked(api.listHelmReleases).mockResolvedValue([]);
   vi.mocked(api.vibrancyEnabled).mockResolvedValue(false);
+  vi.mocked(api.listEvents).mockResolvedValue([]);
+  vi.mocked(api.listRelated).mockResolvedValue([]);
+  vi.mocked(api.listPods).mockResolvedValue([
+    {
+      name: "web-abc",
+      namespace: "prod",
+      phase: "Running",
+      node: "worker-1",
+      ready: "1/1",
+      restarts: 0,
+      age: "3d",
+    },
+  ]);
+  vi.mocked(api.getPod).mockResolvedValue({
+    apiVersion: "v1",
+    kind: "Pod",
+    name: "web-abc",
+    namespace: "prod",
+    phase: "Running",
+    node: "worker-1",
+    podIp: "10.1.2.3",
+    serviceAccount: "default",
+    qosClass: "Burstable",
+    age: "3d",
+    labels: [],
+    annotations: [],
+    containers: [],
+    initContainers: [],
+    conditions: [],
+    yaml: "apiVersion: v1\nkind: Pod\n",
+  });
 });
+
+/// Open the pod list, then the one pod in it.
+async function openPod(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: /Pods/ }));
+  await user.click(await screen.findByText("web-abc"));
+  return screen.findByRole("heading", { name: "web-abc" });
+}
 
 describe("App startup", () => {
   it("reconnects to the session already held in Rust", async () => {
@@ -146,6 +196,221 @@ describe("App navigation", () => {
     await waitFor(() =>
       expect(api.listHelmReleases).toHaveBeenCalled(),
     );
+  });
+});
+
+// Tabs and history. The mechanics are covered in lib/workspace.test.ts;
+// what these assert is that the shell is wired to them — that opening an
+// object keeps the listing it came from, that back retraces the trip,
+// and that a tab is a piece of work you can leave and return to.
+describe("App workspace", () => {
+  it("keeps the listing behind an object it opened", async () => {
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+
+    await openPod(user);
+
+    // The trail says where this came from, which is the whole difference
+    // between a tab and a page that replaced another.
+    const trail = screen.getByRole("navigation", { name: "Trail" });
+    expect(within(trail).getByTitle(/Back to Pods/)).toBeInTheDocument();
+  });
+
+  it("goes back to the listing and forward to the object again", async () => {
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+    await openPod(user);
+
+    await user.click(screen.getByRole("button", { name: "Back" }));
+    expect(await screen.findByRole("heading", { name: "Pods" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Forward" }));
+    expect(
+      await screen.findByRole("heading", { name: "web-abc" }),
+    ).toBeInTheDocument();
+  });
+
+  it("goes back on Escape as well as on the arrow", async () => {
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+    await openPod(user);
+
+    await user.keyboard("{Escape}");
+    expect(await screen.findByRole("heading", { name: "Pods" })).toBeInTheDocument();
+  });
+
+  it("walks back several steps from a crumb", async () => {
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+    await openPod(user);
+
+    const trail = screen.getByRole("navigation", { name: "Trail" });
+    await user.click(within(trail).getByTitle(/Back to Nodes/));
+
+    expect(await screen.findByRole("heading", { name: "Nodes" })).toBeInTheDocument();
+  });
+
+  it("hides the trail at the top of a tab, where there is no path", async () => {
+    renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+    expect(
+      screen.queryByRole("navigation", { name: "Trail" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens a row in its own tab when the modifier is held", async () => {
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+
+    await user.click(screen.getByRole("button", { name: /Pods/ }));
+    const row = await screen.findByText("web-abc");
+    await user.keyboard("{Meta>}");
+    await user.click(row);
+    await user.keyboard("{/Meta}");
+
+    await screen.findByRole("heading", { name: "web-abc" });
+    expect(screen.getAllByRole("tab")).toHaveLength(2);
+  });
+
+  it("leaves the other tab where it was", async () => {
+    // The point of a second tab: the first keeps its place, so going
+    // back to it costs nothing.
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+    await openPod(user);
+
+    await user.keyboard("{Meta>}t{/Meta}");
+    const [first, second] = screen.getAllByRole("tab");
+    expect(second).toHaveAttribute("aria-selected", "true");
+
+    await user.click(first);
+    expect(
+      await screen.findByRole("heading", { name: "web-abc" }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes a tab and shows its neighbour", async () => {
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+
+    await user.keyboard("{Meta>}t{/Meta}");
+    expect(screen.getAllByRole("tab")).toHaveLength(2);
+
+    await user.keyboard("{Meta>}w{/Meta}");
+    await waitFor(() => expect(screen.getAllByRole("tab")).toHaveLength(1));
+    expect(screen.getByRole("heading", { name: "Nodes" })).toBeInTheDocument();
+  });
+
+  it("never leaves the window with no tab at all", async () => {
+    // A window with nothing open has nowhere to render and nothing to
+    // click, so the last tab resets rather than closing.
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+    await openPod(user);
+
+    await user.keyboard("{Meta>}w{/Meta}");
+
+    expect(await screen.findByRole("heading", { name: "Nodes" })).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")).toHaveLength(1);
+  });
+
+  it("reaches a tab by number", async () => {
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+    await openPod(user);
+    await user.keyboard("{Meta>}t{/Meta}");
+
+    await user.keyboard("{Meta>}1{/Meta}");
+    expect(
+      await screen.findByRole("heading", { name: "web-abc" }),
+    ).toBeInTheDocument();
+  });
+
+  it("names each tab after what it is showing", async () => {
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+    expect(screen.getByRole("tab")).toHaveTextContent("Nodes");
+
+    await openPod(user);
+    expect(screen.getByRole("tab")).toHaveTextContent("web-abc");
+  });
+
+  it("follows a related object into another kind, and retraces the chain", async () => {
+    // The trip the Related tab exists for: from a Deployment to the
+    // ConfigMap it mounts. Going back has to land on the Deployment
+    // rather than on the listing, or every step of the chain is lost at
+    // once.
+    vi.mocked(api.listTable).mockResolvedValue({
+      namespaced: true,
+      columns: [{ name: "Name", priority: 0, description: null }],
+      rows: [{ name: "web", namespace: "prod", cells: ["web"] }],
+      continueToken: null,
+      remaining: null,
+    });
+    vi.mocked(api.getObject).mockImplementation(
+      async (resource, namespace, name) =>
+        ({
+          apiVersion: `${resource.group}/${resource.version}`,
+          kind: resource.kind,
+          name,
+          namespace,
+          age: "6d",
+          status: "Ready",
+          labels: [],
+          annotations: [],
+          conditions: [],
+          editable: true,
+          yaml: `kind: ${resource.kind}\n`,
+        }) as never,
+    );
+    vi.mocked(api.listRelated).mockResolvedValue([
+      {
+        relation: "uses",
+        group: "",
+        version: "v1",
+        kind: "ConfigMap",
+        name: "web-config",
+        namespace: "prod",
+        reachable: true,
+        detail: "volume config",
+      },
+    ]);
+
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+
+    await user.click(screen.getByRole("button", { name: "Deployments" }));
+    await user.click(await screen.findByText("web"));
+    await screen.findByRole("heading", { name: "web" });
+
+    await user.click(await screen.findByRole("button", { name: "Related" }));
+    await user.click(await screen.findByRole("button", { name: /web-config/ }));
+    await screen.findByRole("heading", { name: "web-config" });
+
+    // Back to the Deployment, not to the Deployments listing.
+    await user.click(screen.getByRole("button", { name: "Back" }));
+    expect(await screen.findByRole("heading", { name: "web" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Back" }));
+    expect(
+      await screen.findByRole("heading", { name: "Deployments" }),
+    ).toBeInTheDocument();
+  });
+
+  it("starts a fresh workspace when the cluster changes", async () => {
+    // Tabs name objects in the cluster being left. One pointing at a pod
+    // that does not exist here is worse than starting clean.
+    const user = renderApp();
+    await screen.findByRole("heading", { name: "Nodes" });
+    await openPod(user);
+    await user.keyboard("{Meta>}t{/Meta}");
+    expect(screen.getAllByRole("tab")).toHaveLength(2);
+
+    await user.click(screen.getByTitle(/Click to switch cluster/));
+    await user.click(await screen.findByText("orbstack"));
+
+    await waitFor(() => expect(screen.getAllByRole("tab")).toHaveLength(1));
+    expect(screen.getByRole("heading", { name: "Nodes" })).toBeInTheDocument();
   });
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,22 +2,59 @@ import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { CommandPalette } from "./components/CommandPalette";
 import { ShortcutSheet } from "./components/ShortcutSheet";
+import { StatusBar } from "./components/StatusBar";
+import { TabStrip } from "./components/TabStrip";
+import { TrailBar } from "./components/TrailBar";
 import { KIND_SECTIONS } from "./lib/kinds";
 import type { Command } from "./lib/palette";
-import { Sidebar, type View } from "./components/Sidebar";
+import { Sidebar } from "./components/Sidebar";
 import { SkeletonBlock } from "./components/Skeleton";
 import { ContextPicker } from "./pages/ContextPicker";
 import { Namespaces, Nodes, Pods } from "./pages/Resources";
+import { NodeDetail } from "./pages/NodeDetail";
+import { NamespaceDetail } from "./pages/NamespaceDetail";
+import { PodDetail } from "./pages/PodDetail";
+import { ObjectDetail } from "./pages/ObjectDetail";
 import { Crds } from "./pages/Crds";
 import { KindBrowser } from "./pages/KindBrowser";
-import { Helm } from "./pages/Helm";
+import { Helm, ReleaseDetail } from "./pages/Helm";
 import { api, type ClusterInfo, type Guard } from "./lib/api";
 import { ClusterContext } from "./lib/clusterContext";
 import { applyTheme, isDark, parseTheme, type Theme } from "./lib/theme";
+import {
+  parentOf,
+  routeKey,
+  type OpenIntent,
+  type Route,
+} from "./lib/routes";
+import {
+  activeTab,
+  canGoBack,
+  canGoForward,
+  closeActiveTab,
+  closeTab,
+  currentRoute,
+  goBack,
+  goForward,
+  goTo,
+  navigate,
+  newWorkspace,
+  openInNewTab,
+  selectIndex,
+  selectTab,
+  trail,
+  type Workspace,
+} from "./lib/workspace";
 
 export default function App() {
   const [cluster, setCluster] = useState<ClusterInfo | null>(null);
-  const [view, setView] = useState<View>({ type: "nodes" });
+
+  // Where the window is, in full: which tabs are open, what each has
+  // shown, and which one is on screen. Every navigation in the app ends
+  // up here, which is what makes back, forward and the trail work the
+  // same way regardless of what did the navigating.
+  const [workspace, setWorkspace] = useState<Workspace>(() => newWorkspace());
+
   // Shown over a live connection when the user wants a different
   // cluster, so switching does not require disconnecting first.
   const [switching, setSwitching] = useState(false);
@@ -39,6 +76,33 @@ export default function App() {
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
 
   const queryClient = useQueryClient();
+
+  const tab = activeTab(workspace);
+  const route = currentRoute(workspace);
+
+  /// Go somewhere. `intent` is how the click asked to be handled — this
+  /// tab, or one of its own — and is what makes ⌘-clicking a row fan a
+  /// listing out into tabs.
+  function open(next: Route, intent: OpenIntent = "here") {
+    setWorkspace((ws) =>
+      intent === "newTab"
+        ? openInNewTab(ws, next, currentRoute(ws))
+        : navigate(ws, next),
+    );
+  }
+
+  /// Go somewhere from outside a listing — the palette, mostly, where
+  /// there is no current view for the destination to have come from. A
+  /// detail route is seeded with its listing so the trail is not empty
+  /// on arrival.
+  function jump(next: Route) {
+    setWorkspace((ws) => {
+      const under = parentOf(next);
+      return under ? openInNewTab(ws, next, under) : navigate(ws, next);
+    });
+  }
+
+  const back = () => setWorkspace(goBack);
 
   useEffect(() => {
     api
@@ -91,14 +155,14 @@ export default function App() {
   const commands: Command[] = useMemo(() => {
     const out: Command[] = [];
 
-    const goTo = (label: string, view: View, hint?: string, keywords?: string) =>
+    const goTo = (label: string, to: Route, hint?: string, keywords?: string) =>
       out.push({
         id: `view:${label}`,
         group: "Go to",
         label,
         hint,
         keywords,
-        run: () => setView(view),
+        run: () => jump(to),
       });
 
     goTo("Nodes", { type: "nodes" });
@@ -130,7 +194,7 @@ export default function App() {
         group: "Go to",
         label: resource.kind,
         hint: resource.group,
-        run: () => setView({ type: "kind", entry }),
+        run: () => jump({ type: "kind", entry }),
       });
     }
 
@@ -157,6 +221,20 @@ export default function App() {
       });
     }
 
+    out.push({
+      id: "action:new-tab",
+      group: "Action",
+      label: "New tab",
+      keywords: "open split",
+      run: () =>
+        setWorkspace((ws) => openInNewTab(ws, currentRoute(ws))),
+    });
+    out.push({
+      id: "action:close-tab",
+      group: "Action",
+      label: "Close tab",
+      run: () => setWorkspace(closeActiveTab),
+    });
     out.push({
       id: "action:switch",
       group: "Action",
@@ -193,11 +271,43 @@ export default function App() {
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+      const mod = e.metaKey || e.ctrlKey;
+
+      if (mod && e.key.toLowerCase() === "k") {
         e.preventDefault();
         setPaletteOpen((open) => !open);
         return;
       }
+
+      // Tab management. Guarded on the modifier rather than on focus:
+      // these have to work while the cursor is in a filter box, which is
+      // exactly where it is when someone decides to open a second tab.
+      if (mod && e.key.toLowerCase() === "t") {
+        e.preventDefault();
+        setWorkspace((ws) => openInNewTab(ws, currentRoute(ws)));
+        return;
+      }
+      if (mod && e.key.toLowerCase() === "w") {
+        e.preventDefault();
+        setWorkspace(closeActiveTab);
+        return;
+      }
+      if (mod && (e.key === "[" || e.key === "ArrowLeft")) {
+        e.preventDefault();
+        setWorkspace(goBack);
+        return;
+      }
+      if (mod && (e.key === "]" || e.key === "ArrowRight")) {
+        e.preventDefault();
+        setWorkspace(goForward);
+        return;
+      }
+      if (mod && e.key >= "1" && e.key <= "9") {
+        e.preventDefault();
+        setWorkspace((ws) => selectIndex(ws, Number(e.key) - 1));
+        return;
+      }
+
       // `?` only when not typing, or it cannot be typed into a filter.
       const target = e.target as HTMLElement | null;
       const typing =
@@ -254,6 +364,10 @@ export default function App() {
     // screen. Isolating the frontend cache per cluster would remove that
     // too, and wants a key scheme rather than a comment.
     queryClient.clear();
+    // Tabs go with it. They name objects in the cluster being left, and
+    // a tab pointing at a pod that does not exist here is worse than
+    // starting clean.
+    setWorkspace(newWorkspace());
     setCluster(await api.currentCluster());
     setSwitching(false);
   }
@@ -263,6 +377,7 @@ export default function App() {
     // Everything, because every connection is gone. A per-cluster
     // disconnect drops only that cluster's keys.
     queryClient.clear();
+    setWorkspace(newWorkspace());
     setCluster(null);
     setSwitching(false);
   }
@@ -287,28 +402,53 @@ export default function App() {
 
   return (
     <ClusterContext.Provider value={{ context: cluster.context, guard }}>
-      <div className="ambient flex h-full">
-        <Sidebar
+      <div className="ambient flex h-full flex-col">
+        <div className="flex min-h-0 flex-1">
+          <Sidebar
+            route={route}
+            onSelect={open}
+            theme={theme}
+            onThemeChange={chooseTheme}
+          />
+
+          <main className="flex min-w-0 flex-1 flex-col">
+            <TabStrip
+              tabs={workspace.tabs}
+              active={workspace.active}
+              onSelect={(id) => setWorkspace((ws) => selectTab(ws, id))}
+              onClose={(id) => setWorkspace((ws) => closeTab(ws, id))}
+              onNew={() =>
+                setWorkspace((ws) => openInNewTab(ws, currentRoute(ws)))
+              }
+            />
+
+            {/* Only once there is a path to show. At the top of a tab
+                there is nothing behind you, and a bar holding two
+                disabled arrows is chrome paying no rent. */}
+            {canGoBack(tab) && (
+              <TrailBar
+                trail={trail(tab)}
+                canBack={canGoBack(tab)}
+                canForward={canGoForward(tab)}
+                onBack={back}
+                onForward={() => setWorkspace(goForward)}
+                onCrumb={(i) => setWorkspace((ws) => goTo(ws, i))}
+              />
+            )}
+
+            <div className="min-h-0 flex-1">
+              <View route={route} open={open} back={back} />
+            </div>
+          </main>
+        </div>
+
+        <StatusBar
           cluster={cluster}
-          view={view}
-          onSelect={setView}
-          theme={theme}
-          onThemeChange={chooseTheme}
           guard={guard}
           onGuardChange={chooseGuard}
           onSwitchCluster={() => setSwitching(true)}
           onDisconnect={disconnect}
         />
-        <main className="min-w-0 flex-1">
-          {view.type === "nodes" && <Nodes />}
-          {view.type === "namespaces" && <Namespaces />}
-          {view.type === "pods" && <Pods />}
-          {view.type === "crds" && (
-            <Crds onSelectKind={(entry) => setView({ type: "kind", entry })} />
-          )}
-          {view.type === "kind" && <KindBrowser entry={view.entry} />}
-          {view.type === "helm" && <Helm />}
-        </main>
 
         {paletteOpen && (
           <CommandPalette
@@ -322,4 +462,132 @@ export default function App() {
       </div>
     </ClusterContext.Provider>
   );
+}
+
+/// One route, rendered.
+///
+/// Every page here is either a listing that reports what was opened, or
+/// a detail view that reports where it wants to go next. None of them
+/// decides what happens as a result — that is the workspace's, which is
+/// why the same pod row can open in this tab or a new one without the
+/// pod list knowing either exists.
+function View({
+  route,
+  open,
+  back,
+}: {
+  route: Route;
+  open: (route: Route, intent?: OpenIntent) => void;
+  back: () => void;
+}) {
+  switch (route.type) {
+    case "nodes":
+      return <Nodes onOpen={(n, i) => open({ type: "node", name: n.name }, i)} />;
+
+    case "namespaces":
+      return (
+        <Namespaces
+          onOpen={(n, i) => open({ type: "namespace", name: n.name }, i)}
+        />
+      );
+
+    case "pods":
+      return (
+        <Pods
+          onOpen={(p, i) =>
+            open({ type: "pod", namespace: p.namespace, name: p.name }, i)
+          }
+        />
+      );
+
+    case "crds":
+      return <Crds onSelectKind={(entry) => open({ type: "kind", entry })} />;
+
+    case "helm":
+      return (
+        <Helm
+          onOpen={(r, i) =>
+            open({ type: "release", namespace: r.namespace, name: r.name }, i)
+          }
+        />
+      );
+
+    case "kind":
+      return (
+        <KindBrowser
+          entry={route.entry}
+          onOpen={(row, i) =>
+            open(
+              {
+                type: "object",
+                resource: route.entry.gvk,
+                namespace: row.namespace,
+                name: row.name,
+              },
+              i,
+            )
+          }
+        />
+      );
+
+    case "node":
+      return <NodeDetail key={route.name} name={route.name} onClose={back} />;
+
+    case "namespace":
+      return (
+        <NamespaceDetail
+          key={route.name}
+          name={route.name}
+          onClose={back}
+          onOpenPod={(pod) =>
+            open({ type: "pod", namespace: pod.namespace, name: pod.name })
+          }
+        />
+      );
+
+    case "pod":
+      return (
+        <PodDetail
+          key={routeKey(route)}
+          namespace={route.namespace}
+          name={route.name}
+          onClose={back}
+        />
+      );
+
+    case "release":
+      return (
+        <ReleaseDetail
+          key={routeKey(route)}
+          namespace={route.namespace}
+          name={route.name}
+          onClose={back}
+        />
+      );
+
+    case "object":
+      return (
+        <ObjectDetail
+          // Keyed so following a related object remounts rather than
+          // showing the previous object's tab state over the new one.
+          key={routeKey(route)}
+          resource={route.resource}
+          namespace={route.namespace}
+          name={route.name}
+          onClose={back}
+          onOpenRelated={(related) =>
+            open({
+              type: "object",
+              resource: {
+                group: related.group,
+                version: related.version,
+                kind: related.kind,
+              },
+              namespace: related.namespace,
+              name: related.name,
+            })
+          }
+        />
+      );
+  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,8 +23,11 @@ import { ClusterContext } from "./lib/clusterContext";
 import { applyTheme, isDark, parseTheme, type Theme } from "./lib/theme";
 import {
   crumbsFor,
+  listViewOf,
   parentOf,
   routeKey,
+  withListView,
+  type ListView,
   type OpenIntent,
   type Route,
 } from "./lib/routes";
@@ -40,6 +43,7 @@ import {
   navigate,
   newWorkspace,
   openInNewTab,
+  replace,
   selectIndex,
   selectTab,
   type Workspace,
@@ -100,6 +104,14 @@ export default function App() {
       const under = parentOf(next);
       return under ? openInNewTab(ws, next, under) : navigate(ws, next);
     });
+  }
+
+  /// Change how the listing on screen is presented — its namespace, its
+  /// search text, its sort. Replaces rather than pushes: this is the
+  /// same destination shown differently, and pushing would make back
+  /// mean "undo my last keystroke".
+  function changeView(patch: Partial<ListView>) {
+    setWorkspace((ws) => replace(ws, withListView(currentRoute(ws), patch)));
   }
 
   const back = () => setWorkspace(goBack);
@@ -439,7 +451,12 @@ export default function App() {
             )}
 
             <div className="min-h-0 flex-1">
-              <View route={route} open={open} back={back} />
+              <View
+                route={route}
+                open={open}
+                back={back}
+                onView={changeView}
+              />
             </div>
           </main>
         </div>
@@ -477,19 +494,31 @@ function View({
   route,
   open,
   back,
+  onView,
 }: {
   route: Route;
   open: (route: Route, intent?: OpenIntent) => void;
   back: () => void;
+  onView: (patch: Partial<ListView>) => void;
 }) {
+  const view = listViewOf(route);
+
   switch (route.type) {
     case "nodes":
-      return <Nodes onOpen={(n, i) => open({ type: "node", name: n.name }, i)} />;
+      return (
+        <Nodes
+          onOpen={(n, i) => open({ type: "node", name: n.name }, i)}
+          view={view}
+          onView={onView}
+        />
+      );
 
     case "namespaces":
       return (
         <Namespaces
           onOpen={(n, i) => open({ type: "namespace", name: n.name }, i)}
+          view={view}
+          onView={onView}
         />
       );
 
@@ -499,6 +528,8 @@ function View({
           onOpen={(p, i) =>
             open({ type: "pod", namespace: p.namespace, name: p.name }, i)
           }
+          view={view}
+          onView={onView}
         />
       );
 
@@ -511,6 +542,8 @@ function View({
           onOpen={(r, i) =>
             open({ type: "release", namespace: r.namespace, name: r.name }, i)
           }
+          view={view}
+          onView={onView}
         />
       );
 
@@ -529,6 +562,8 @@ function View({
               i,
             )
           }
+          view={view}
+          onView={onView}
         />
       );
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,13 +150,16 @@ export default function App() {
   // The menu says what was asked for and this decides what it means, so
   // the menu item and the keystroke cannot drift apart.
   useEffect(() => {
+    // Caught here rather than on the way out: without a bridge this
+    // rejects immediately, and a rejection only handled at cleanup is
+    // unhandled for as long as the app is mounted — which is the whole
+    // session, and every test that renders it.
     const unlisten = listen<string>(ZOOM_EVENT, (event) => {
       if (event.payload === ZOOM_IN) changeZoom(zoomIn);
       else if (event.payload === ZOOM_OUT) changeZoom(zoomOut);
       else if (event.payload === ZOOM_RESET) changeZoom(() => DEFAULT_ZOOM);
-    });
-    // No bridge in browser dev, where there is no menu to listen to.
-    return () => void unlisten.then((off) => off()).catch(() => {});
+    }).catch(() => null);
+    return () => void unlisten.then((off) => off?.());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { api, type ClusterInfo, type Guard } from "./lib/api";
 import { ClusterContext } from "./lib/clusterContext";
 import { applyTheme, isDark, parseTheme, type Theme } from "./lib/theme";
 import {
+  crumbsFor,
   parentOf,
   routeKey,
   type OpenIntent,
@@ -36,13 +37,11 @@ import {
   currentRoute,
   goBack,
   goForward,
-  goTo,
   navigate,
   newWorkspace,
   openInNewTab,
   selectIndex,
   selectTab,
-  trail,
   type Workspace,
 } from "./lib/workspace";
 
@@ -79,6 +78,7 @@ export default function App() {
 
   const tab = activeTab(workspace);
   const route = currentRoute(workspace);
+  const crumbs = crumbsFor(route);
 
   /// Go somewhere. `intent` is how the click asked to be handled — this
   /// tab, or one of its own — and is what makes ⌘-clicking a row fan a
@@ -422,17 +422,19 @@ export default function App() {
               }
             />
 
-            {/* Only once there is a path to show. At the top of a tab
-                there is nothing behind you, and a bar holding two
-                disabled arrows is chrome paying no rent. */}
-            {canGoBack(tab) && (
+            {/* Shown when it has something to say: an object sitting
+                somewhere, or a history worth stepping through. On a
+                listing opened fresh it is one crumb repeating the
+                heading below it and two dead arrows — chrome paying no
+                rent. */}
+            {(crumbs.length > 1 || canGoBack(tab) || canGoForward(tab)) && (
               <TrailBar
-                trail={trail(tab)}
+                crumbs={crumbs}
                 canBack={canGoBack(tab)}
                 canForward={canGoForward(tab)}
                 onBack={back}
                 onForward={() => setWorkspace(goForward)}
-                onCrumb={(i) => setWorkspace((ws) => goTo(ws, i))}
+                onCrumb={(to) => open(to)}
               />
             )}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { CommandPalette } from "./components/CommandPalette";
 import { ShortcutSheet } from "./components/ShortcutSheet";
@@ -21,6 +22,17 @@ import { Helm, ReleaseDetail } from "./pages/Helm";
 import { api, type ClusterInfo, type Guard } from "./lib/api";
 import { ClusterContext } from "./lib/clusterContext";
 import { applyTheme, isDark, parseTheme, type Theme } from "./lib/theme";
+import {
+  applyZoom,
+  clampZoom,
+  DEFAULT_ZOOM,
+  ZOOM_EVENT,
+  ZOOM_IN,
+  ZOOM_OUT,
+  ZOOM_RESET,
+  zoomIn,
+  zoomOut,
+} from "./lib/zoom";
 import {
   crumbsFor,
   listViewOf,
@@ -68,6 +80,11 @@ export default function App() {
   // App owns the appearance: the picker sets it, the OS feeds into it
   // when the preference is "system", and one effect applies the result.
   const [theme, setTheme] = useState<Theme>("system");
+
+  // Interface scale. Stored rather than reset each launch, because
+  // someone who needs 150% needs it every time — a size you have to
+  // re-ask for at every start is the same as not having the control.
+  const [zoom, setZoom] = useState(DEFAULT_ZOOM);
 
   // What the connected context allows. Held here because every write
   // path needs it and none of the pages in between should have to carry
@@ -119,10 +136,28 @@ export default function App() {
   useEffect(() => {
     api
       .getSettings()
-      .then((s) => setTheme(parseTheme(s.theme)))
+      .then((s) => {
+        setTheme(parseTheme(s.theme));
+        setZoom(clampZoom(s.zoom));
+      })
       // No settings file yet, or no bridge in browser dev. Following the
-      // system is the right fallback either way.
+      // system at the default size is the right fallback either way.
       .catch(() => {});
+  }, []);
+
+  useEffect(() => applyZoom(zoom), [zoom]);
+
+  // The menu says what was asked for and this decides what it means, so
+  // the menu item and the keystroke cannot drift apart.
+  useEffect(() => {
+    const unlisten = listen<string>(ZOOM_EVENT, (event) => {
+      if (event.payload === ZOOM_IN) changeZoom(zoomIn);
+      else if (event.payload === ZOOM_OUT) changeZoom(zoomOut);
+      else if (event.payload === ZOOM_RESET) changeZoom(() => DEFAULT_ZOOM);
+    });
+    // No bridge in browser dev, where there is no menu to listen to.
+    return () => void unlisten.then((off) => off()).catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -260,6 +295,30 @@ export default function App() {
       label: "Disconnect",
       run: () => void disconnect(),
     });
+    // Reachable without the menu, which is macOS-only, and without the
+    // keystroke, which is the thing someone who needs this may be least
+    // able to discover.
+    out.push({
+      id: "action:zoom-in",
+      group: "Action",
+      label: "Zoom in",
+      keywords: "larger bigger text size accessibility",
+      run: () => changeZoom(zoomIn),
+    });
+    out.push({
+      id: "action:zoom-out",
+      group: "Action",
+      label: "Zoom out",
+      keywords: "smaller text size accessibility",
+      run: () => changeZoom(zoomOut),
+    });
+    out.push({
+      id: "action:zoom-reset",
+      group: "Action",
+      label: "Actual size",
+      keywords: "zoom reset 100%",
+      run: () => changeZoom(() => DEFAULT_ZOOM),
+    });
     out.push({
       id: "action:shortcuts",
       group: "Action",
@@ -320,6 +379,25 @@ export default function App() {
         return;
       }
 
+      // Zoom. Bound here as well as on the menu so it works on the
+      // platforms with no menu bar, and so `=` reaches it without the
+      // shift that would otherwise be needed to type `+`.
+      if (mod && (e.key === "=" || e.key === "+")) {
+        e.preventDefault();
+        changeZoom(zoomIn);
+        return;
+      }
+      if (mod && (e.key === "-" || e.key === "_")) {
+        e.preventDefault();
+        changeZoom(zoomOut);
+        return;
+      }
+      if (mod && e.key === "0") {
+        e.preventDefault();
+        changeZoom(() => DEFAULT_ZOOM);
+        return;
+      }
+
       // `?` only when not typing, or it cannot be typed into a filter.
       const target = e.target as HTMLElement | null;
       const typing =
@@ -345,6 +423,17 @@ export default function App() {
       // failed to apply, so put it back.
       await api.contextGuard(cluster.context).then(setGuard).catch(() => {});
     }
+  }
+
+  /// Step the scale and remember it. Applied first, like the theme: the
+  /// keystroke should land immediately, and a size that failed to
+  /// persist is still the one the user asked for.
+  function changeZoom(next: (level: number) => number) {
+    setZoom((level) => {
+      const to = clampZoom(next(level));
+      void api.setZoom(to).catch(() => {});
+      return to;
+    });
   }
 
   async function chooseTheme(next: Theme) {

--- a/src/components/DetailShell.test.tsx
+++ b/src/components/DetailShell.test.tsx
@@ -19,7 +19,6 @@ function setup(tab = "overview") {
       tab={tab}
       onTab={onTab}
       onClose={onClose}
-      backTo="pods"
     >
       <textarea aria-label="Object YAML" defaultValue="kind: Pod" />
     </DetailShell>,
@@ -54,9 +53,13 @@ describe("DetailShell", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it("names what the back button returns to", () => {
+  it("leaves navigation to the trail bar above it", () => {
+    // Back, forward and the trail belong to the workspace, which knows
+    // the whole path; a second back button here would only know the one
+    // step this page was given.
     setup();
-    expect(screen.getByRole("button", { name: "Back to pods" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Back/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Close" })).not.toBeInTheDocument();
   });
 
   it("shows an error without hiding the content underneath", () => {

--- a/src/components/DetailShell.tsx
+++ b/src/components/DetailShell.tsx
@@ -5,10 +5,15 @@ import { dragRegionProps } from "../lib/window";
 // The frame every detail page sits in.
 //
 // Same shape as Panel — glass header, error strip, scrolling body — plus
-// a back affordance and a tab bar, because a detail view is always
-// several views of one object. Extracted so pods, nodes, namespaces,
-// custom resources and Helm releases cannot drift apart in how they
-// present themselves.
+// a tab bar, because a detail view is always several views of one
+// object. Extracted so pods, nodes, namespaces, custom resources and
+// Helm releases cannot drift apart in how they present themselves.
+//
+// Going back is not this component's job any more: the trail bar above
+// owns it, for every route rather than only for detail views. What is
+// left here is Escape, which stays because a reader's hand is already
+// on the keyboard and it is the one binding people try without being
+// told.
 
 export interface TabSpec {
   id: string;
@@ -23,9 +28,9 @@ interface DetailShellProps {
   tabs: TabSpec[];
   tab: string;
   onTab: (id: string) => void;
+  /// Escape. Wired to the trail bar's back, so the key and the arrow
+  /// do the same thing.
   onClose: () => void;
-  /// What the back button returns to, for its tooltip.
-  backTo?: string;
   error?: unknown;
   actions?: ReactNode;
   children: ReactNode;
@@ -39,7 +44,6 @@ export function DetailShell({
   tab,
   onTab,
   onClose,
-  backTo,
   error,
   actions,
   children,
@@ -58,37 +62,19 @@ export function DetailShell({
 
   return (
     <section className="flex h-full flex-col">
-      <header {...dragRegionProps} className="drag-region glass border-b px-4 pb-3 pt-10">
+      <header {...dragRegionProps} className="drag-region glass border-b px-4 pb-3 pt-3">
         <div className="flex items-center justify-between gap-3">
           <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <button
-                onClick={onClose}
-                className="no-drag rounded-sm px-1.5 text-content-muted transition-colors hover:bg-content/[0.06] hover:text-content"
-                title={backTo ? `Back to ${backTo}` : "Back"}
-                aria-label={backTo ? `Back to ${backTo}` : "Back"}
-              >
-                ←
-              </button>
               <h2 className="truncate font-semibold">{title}</h2>
               {badge}
             </div>
             {subtitle && (
-              <p className="truncate pl-8 text-2xs text-content-muted">
-                {subtitle}
-              </p>
+              <p className="truncate text-2xs text-content-muted">{subtitle}</p>
             )}
           </div>
 
-          <div className="no-drag flex shrink-0 items-center gap-2">
-            {actions}
-            <button
-              onClick={onClose}
-              className="shrink-0 rounded-sm border px-2 py-1 text-2xs text-content-secondary transition-colors duration-150 ease-swift hover:bg-content/[0.06] hover:text-content"
-            >
-              Close
-            </button>
-          </div>
+          <div className="no-drag flex shrink-0 items-center gap-2">{actions}</div>
         </div>
 
         <nav className="no-drag mt-3 flex gap-1">

--- a/src/components/DetailShell.tsx
+++ b/src/components/DetailShell.tsx
@@ -97,7 +97,11 @@ export function DetailShell({
 
       {error != null && <ErrorStrip error={error} />}
 
-      <div className="min-h-0 flex-1 overflow-hidden">{children}</div>
+      {/* The content plane, same as Panel's — a detail view and a
+          listing are the same kind of surface and must not differ. */}
+      <div className="min-h-0 flex-1 overflow-hidden bg-surface-1">
+        {children}
+      </div>
     </section>
   );
 }

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -59,7 +59,11 @@ export function Panel({
 
       {error != null && <ErrorStrip error={error} />}
 
-      <div className="min-h-0 flex-1">{children}</div>
+      {/* The content plane. Without it a listing sits on the window's
+          own background, which is dimmer than the glass framing it —
+          so the table, the largest thing on screen, reads as the
+          dullest. */}
+      <div className="min-h-0 flex-1 bg-surface-1">{children}</div>
     </section>
   );
 }

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -30,7 +30,7 @@ export function Panel({
     <section className="flex h-full flex-col">
       <header
         {...dragRegionProps}
-        className="drag-region glass flex items-center justify-between gap-3 border-b px-4 pb-3 pt-10"
+        className="drag-region glass flex items-center justify-between gap-3 border-b px-4 pb-3 pt-3"
       >
         <div className="min-w-0">
           <h2 className="truncate text-sm font-semibold tracking-tight">

--- a/src/components/ResourceTable.test.tsx
+++ b/src/components/ResourceTable.test.tsx
@@ -233,7 +233,31 @@ describe("Table rows", () => {
     );
 
     await user.click(screen.getByText("pod-000"));
-    expect(onRowClick).toHaveBeenCalledWith({ name: "pod-000", phase: "Running" });
+    expect(onRowClick).toHaveBeenCalledWith(
+      { name: "pod-000", phase: "Running" },
+      "here",
+    );
+  });
+
+  it("asks for a new tab when a row is clicked with the modifier held", async () => {
+    // The row reports how it was opened and lets the caller decide what
+    // that means, the same way a link does.
+    const onRowClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Table
+        columns={COLUMNS}
+        rows={rows(1)}
+        rowKey={(r) => r.name}
+        onRowClick={onRowClick}
+      />,
+    );
+
+    await user.keyboard("{Meta>}");
+    await user.click(screen.getByText("pod-000"));
+    await user.keyboard("{/Meta}");
+
+    expect(onRowClick).toHaveBeenCalledWith(expect.anything(), "newTab");
   });
 
   it("opens a row from the keyboard", async () => {

--- a/src/components/ResourceTable.test.tsx
+++ b/src/components/ResourceTable.test.tsx
@@ -15,9 +15,29 @@ interface Row {
 }
 
 const COLUMNS: Column<Row>[] = [
-  { key: "name", header: "Name", render: (r) => r.name },
-  { key: "phase", header: "Phase", render: (r) => r.phase, mono: true },
+  { key: "name", header: "Name", render: (r) => r.name, sortValue: (r) => r.name },
+  {
+    key: "phase",
+    header: "Phase",
+    render: (r) => r.phase,
+    mono: true,
+    sortValue: (r) => r.phase,
+  },
 ];
+
+/// A column with no `sortValue`, which is how a view says "this one
+/// cannot be sorted" — a cell of chips has no order to speak of.
+const UNSORTABLE: Column<Row>[] = [
+  { key: "name", header: "Name", render: (r) => r.name },
+];
+
+/// The names in the body, top to bottom.
+function names() {
+  return screen
+    .getAllByRole("row")
+    .slice(1)
+    .map((row) => row.querySelectorAll("td")[0].textContent);
+}
 
 function rows(count: number, phase = "Running"): Row[] {
   return Array.from({ length: count }, (_, i) => ({
@@ -154,6 +174,127 @@ describe("ResourceTable search", () => {
     const user = renderTable({ searchText: (r: Row) => r.name });
     await user.type(screen.getByPlaceholderText("Search…"), "Running");
     expect(screen.getByText(/Nothing matches/)).toBeInTheDocument();
+  });
+});
+
+describe("ResourceTable sorting", () => {
+  const UNSORTED: Row[] = [
+    { name: "pod-b", phase: "Running" },
+    { name: "pod-c", phase: "Failed" },
+    { name: "pod-a", phase: "Pending" },
+  ];
+
+  it("leaves the rows in the server's order until asked", () => {
+    // That order is what `kubectl get` prints, so it is a real answer
+    // rather than an arbitrary starting point.
+    renderTable({ rows: UNSORTED });
+    expect(names()).toEqual(["pod-b", "pod-c", "pod-a"]);
+  });
+
+  it("sorts ascending on the first click", async () => {
+    const user = renderTable({ rows: UNSORTED });
+    await user.click(screen.getByRole("button", { name: /Name/ }));
+    expect(names()).toEqual(["pod-a", "pod-b", "pod-c"]);
+  });
+
+  it("reverses on the second, and returns to the server's order on the third", async () => {
+    const user = renderTable({ rows: UNSORTED });
+    const header = screen.getByRole("button", { name: /Name/ });
+
+    await user.click(header);
+    await user.click(header);
+    expect(names()).toEqual(["pod-c", "pod-b", "pod-a"]);
+
+    await user.click(header);
+    expect(names()).toEqual(["pod-b", "pod-c", "pod-a"]);
+  });
+
+  it("starts the new column ascending when a different header is clicked", async () => {
+    const user = renderTable({ rows: UNSORTED });
+    await user.click(screen.getByRole("button", { name: /Name/ }));
+    await user.click(screen.getByRole("button", { name: /Name/ }));
+    await user.click(screen.getByRole("button", { name: /Phase/ }));
+
+    expect(names()).toEqual(["pod-c", "pod-a", "pod-b"]);
+  });
+
+  it("says which column is sorted, and which way", async () => {
+    const user = renderTable({ rows: UNSORTED });
+    const name = () => screen.getByRole("columnheader", { name: /Name/ });
+    expect(name()).toHaveAttribute("aria-sort", "none");
+
+    await user.click(screen.getByRole("button", { name: /Name/ }));
+    expect(name()).toHaveAttribute("aria-sort", "ascending");
+
+    await user.click(screen.getByRole("button", { name: /Name/ }));
+    expect(name()).toHaveAttribute("aria-sort", "descending");
+  });
+
+  it("leaves a column with nothing to sort by inert", () => {
+    // A cell of chips has no order to speak of, and a header that looks
+    // clickable but does nothing is worse than one that does not.
+    renderTable({ columns: UNSORTABLE });
+    expect(
+      screen.queryByRole("button", { name: /Name/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Name" })).not.toHaveAttribute(
+      "aria-sort",
+    );
+  });
+
+  it("sorts the whole set rather than the page on screen", async () => {
+    // Sorting only the visible page would put the smallest of the first
+    // fifty at the top and call it the smallest.
+    const user = renderTable({ rows: rows(120) });
+    await user.click(screen.getByRole("button", { name: /Name/ }));
+    await user.click(screen.getByRole("button", { name: /Name/ }));
+
+    expect(names()[0]).toBe("pod-119");
+  });
+
+  it("returns to the first page, where the rows now are", async () => {
+    const user = renderTable({ rows: rows(120) });
+    await user.click(screen.getByRole("button", { name: "›" }));
+    expect(screen.getByText("2 / 3")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Name/ }));
+    expect(screen.getByText("1 / 3")).toBeInTheDocument();
+  });
+
+  it("sorts within a search rather than across everything", async () => {
+    const user = renderTable({
+      rows: [
+        { name: "kube-b", phase: "Running" },
+        { name: "app", phase: "Running" },
+        { name: "kube-a", phase: "Running" },
+      ],
+    });
+    await user.type(screen.getByPlaceholderText("Search…"), "kube");
+    await user.click(screen.getByRole("button", { name: /Name/ }));
+
+    expect(names()).toEqual(["kube-a", "kube-b"]);
+  });
+
+  it("warns that a sort only covered what is loaded", async () => {
+    // A sort hides a partial listing better than a search does: the rows
+    // come back convincingly ordered with the real top of the list still
+    // sitting on the server.
+    const user = renderTable({ hasMore: true, remaining: 19_500 });
+    await user.click(screen.getByRole("button", { name: /Name/ }));
+
+    expect(
+      screen.getByText(/the sort covers only what is loaded/),
+    ).toBeInTheDocument();
+  });
+
+  it("names both when a search and a sort are in play", async () => {
+    const user = renderTable({ hasMore: true, remaining: 19_500 });
+    await user.type(screen.getByPlaceholderText("Search…"), "pod");
+    await user.click(screen.getByRole("button", { name: /Name/ }));
+
+    expect(
+      screen.getByText(/search and sort cover only what is loaded/),
+    ).toBeInTheDocument();
   });
 });
 

--- a/src/components/ResourceTable.tsx
+++ b/src/components/ResourceTable.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Table, type Column } from "./Table";
 import { SkeletonRows } from "./Skeleton";
 import type { OpenIntent } from "../lib/routes";
+import { nextSort, sortRows, type SortState } from "../lib/sort";
 
 const PAGE_SIZE = 50;
 
@@ -44,6 +45,9 @@ export function ResourceTable<T>({
 }: ResourceTableProps<T>) {
   const [query, setQuery] = useState("");
   const [page, setPage] = useState(0);
+  // Null is the order the server sent, which for a Kubernetes listing is
+  // meaningful in its own right — it is what `kubectl get` prints.
+  const [sort, setSort] = useState<SortState | null>(null);
 
   const filtered = useMemo(() => {
     if (!rows) return [];
@@ -58,7 +62,22 @@ export function ResourceTable<T>({
     });
   }, [rows, query, searchText]);
 
-  const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  // After filtering and before paging, so page 1 holds the first rows of
+  // the sorted set rather than the sorted first page.
+  const ordered = useMemo(() => {
+    if (!sort) return filtered;
+    const column = columns.find((c) => c.key === sort.key);
+    if (!column?.sortValue) return filtered;
+    return sortRows(filtered, column.sortValue, sort.direction);
+  }, [filtered, sort, columns]);
+
+  function chooseSort(key: string) {
+    setSort((current) => nextSort(current, key));
+    // The row that was on page 3 is somewhere else entirely now.
+    setPage(0);
+  }
+
+  const pageCount = Math.max(1, Math.ceil(ordered.length / PAGE_SIZE));
 
   // Filtering can strip away the page the user was on; clamp rather than
   // showing an empty table below a non-empty result count.
@@ -67,7 +86,20 @@ export function ResourceTable<T>({
   }, [page, pageCount]);
 
   const start = page * PAGE_SIZE;
-  const visible = filtered.slice(start, start + PAGE_SIZE);
+  const visible = ordered.slice(start, start + PAGE_SIZE);
+
+  // A sort over a partly loaded listing has not sorted the cluster, in
+  // exactly the way a search over one has not searched it — and a sort
+  // hides that better, because the rows come back convincingly ordered
+  // with the real top of the list still on the server.
+  const partial =
+    query && sort
+      ? "search and sort cover"
+      : query
+        ? "search covers"
+        : sort
+          ? "the sort covers"
+          : null;
 
   return (
     <div className="flex h-full flex-col">
@@ -94,7 +126,7 @@ export function ResourceTable<T>({
             className="shrink-0 text-2xs tabular-nums text-content-muted"
             title={
               hasMore
-                ? "More objects exist in the cluster than have been loaded, so search covers what is here"
+                ? "More objects exist in the cluster than have been loaded, so searching and sorting cover only what is here"
                 : undefined
             }
           >
@@ -122,6 +154,8 @@ export function ResourceTable<T>({
               rows={visible}
               rowKey={rowKey}
               onRowClick={onRowClick}
+              sort={sort}
+              onSort={chooseSort}
               empty={
                 query
                   ? `Nothing matches “${query}”.`
@@ -137,7 +171,7 @@ export function ResourceTable<T>({
           <span className="min-w-0 truncate text-content-secondary">
             Showing the first {rows?.length ?? 0}
             {remaining !== null && ` of ${(rows?.length ?? 0) + remaining}`}
-            {query && " — search covers only what is loaded"}
+            {partial && ` — ${partial} only what is loaded`}
           </span>
           <button
             onClick={onLoadMore}
@@ -152,8 +186,8 @@ export function ResourceTable<T>({
       {pageCount > 1 && (
         <div className="flex items-center justify-between border-t px-4 py-1.5 text-2xs">
           <span className="tabular-nums text-content-muted">
-            {start + 1}–{Math.min(start + PAGE_SIZE, filtered.length)} of{" "}
-            {filtered.length}
+            {start + 1}–{Math.min(start + PAGE_SIZE, ordered.length)} of{" "}
+            {ordered.length}
           </span>
           <span className="flex items-center gap-1">
             <PageButton

--- a/src/components/ResourceTable.tsx
+++ b/src/components/ResourceTable.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Table, type Column } from "./Table";
 import { SkeletonRows } from "./Skeleton";
-import type { OpenIntent } from "../lib/routes";
+import type { ListView, OpenIntent } from "../lib/routes";
 import { nextSort, sortRows, type SortState } from "../lib/sort";
 
 const PAGE_SIZE = 50;
@@ -27,6 +27,16 @@ export interface ResourceTableProps<T> {
   remaining?: number | null;
   loadingMore?: boolean;
   onLoadMore?: () => void;
+  /// The search text and sort, when the caller wants them to outlive
+  /// this component. A listing does: it unmounts the moment you open a
+  /// row, and a filter that evaporates on the way to a pod and back is
+  /// the filter you have to retype every time.
+  ///
+  /// Omitted by the small fixed tables inside a detail view, which are
+  /// gone for good when you leave and have nothing worth keeping. They
+  /// fall back to holding it themselves.
+  view?: ListView;
+  onView?: (patch: Partial<ListView>) => void;
 }
 
 export function ResourceTable<T>({
@@ -42,12 +52,25 @@ export function ResourceTable<T>({
   remaining = null,
   loadingMore = false,
   onLoadMore,
+  view,
+  onView,
 }: ResourceTableProps<T>) {
-  const [query, setQuery] = useState("");
   const [page, setPage] = useState(0);
-  // Null is the order the server sent, which for a Kubernetes listing is
-  // meaningful in its own right — it is what `kubectl get` prints.
-  const [sort, setSort] = useState<SortState | null>(null);
+
+  // Held by the caller when it offered somewhere to hold it, and here
+  // otherwise. Null sort is the order the server sent, which for a
+  // Kubernetes listing is meaningful in its own right — it is what
+  // `kubectl get` prints.
+  const [ownQuery, setOwnQuery] = useState("");
+  const [ownSort, setOwnSort] = useState<SortState | null>(null);
+
+  const kept = onView != null;
+  const query = kept ? (view?.query ?? "") : ownQuery;
+  const sort = kept ? (view?.sort ?? null) : ownSort;
+  const setQuery = (next: string) =>
+    kept ? onView({ query: next }) : setOwnQuery(next);
+  const setSort = (next: SortState | null) =>
+    kept ? onView({ sort: next }) : setOwnSort(next);
 
   const filtered = useMemo(() => {
     if (!rows) return [];
@@ -72,7 +95,7 @@ export function ResourceTable<T>({
   }, [filtered, sort, columns]);
 
   function chooseSort(key: string) {
-    setSort((current) => nextSort(current, key));
+    setSort(nextSort(sort, key));
     // The row that was on page 3 is somewhere else entirely now.
     setPage(0);
   }

--- a/src/components/ResourceTable.tsx
+++ b/src/components/ResourceTable.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Table, type Column } from "./Table";
 import { SkeletonRows } from "./Skeleton";
+import type { OpenIntent } from "../lib/routes";
 
 const PAGE_SIZE = 50;
 
@@ -13,7 +14,7 @@ export interface ResourceTableProps<T> {
   searchText: (row: T) => string;
   isLoading: boolean;
   empty?: string;
-  onRowClick?: (row: T) => void;
+  onRowClick?: (row: T, intent: OpenIntent) => void;
   /// Extra controls rendered to the left of the search box.
   toolbar?: ReactNode;
   /// True when the cluster holds more objects than have been fetched.

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -12,11 +12,15 @@ export function Select({
   onChange,
   children,
   title,
+  dense,
 }: {
   value: string;
   onChange: (value: string) => void;
   children: ReactNode;
   title?: string;
+  /// For the status bar, where the row is shorter than a toolbar's and
+  /// a full-size control would set the height of the whole line.
+  dense?: boolean;
 }) {
   return (
     <span className="relative inline-flex shrink-0 items-center">
@@ -24,13 +28,19 @@ export function Select({
         value={value}
         title={title}
         onChange={(e) => onChange(e.target.value)}
-        className="appearance-none rounded-sm border bg-content/[0.03] py-1 pl-2.5 pr-7 text-sm transition-colors duration-150 ease-swift hover:bg-content/[0.06] focus:border-accent/40"
+        className={`appearance-none rounded-sm border bg-content/[0.03] transition-colors duration-150 ease-swift hover:bg-content/[0.06] focus:border-accent/40 ${
+          dense ? "py-0 pl-1.5 pr-5 text-2xs" : "py-1 pl-2.5 pr-7 text-sm"
+        }`}
       >
         {children}
       </select>
       {/* Chevron sits over the control; pointer-events off so clicks
           still reach the select underneath. */}
-      <span className="pointer-events-none absolute right-2 text-2xs text-content-muted">
+      <span
+        className={`pointer-events-none absolute text-2xs text-content-muted ${
+          dense ? "right-1.5" : "right-2"
+        }`}
+      >
         ▾
       </span>
     </span>

--- a/src/components/ShortcutSheet.tsx
+++ b/src/components/ShortcutSheet.tsx
@@ -9,7 +9,12 @@ const SHORTCUTS: { keys: string; what: string }[] = [
   { keys: "⌘K / Ctrl-K", what: "Open the command palette" },
   { keys: "↑ ↓", what: "Move through the palette" },
   { keys: "↵", what: "Run the selected command" },
-  { keys: "Esc", what: "Close the palette, or go back from a detail view" },
+  { keys: "⌘T", what: "New tab, on whatever is open" },
+  { keys: "⌘W", what: "Close the tab" },
+  { keys: "⌘1 … ⌘9", what: "Go to a tab by position" },
+  { keys: "⌘[ / ⌘]", what: "Back and forward through the trail" },
+  { keys: "⌘-click", what: "Open a row in a tab of its own" },
+  { keys: "Esc", what: "Close the palette, or go back" },
   { keys: "?", what: "Show this list" },
 ];
 

--- a/src/components/ShortcutSheet.tsx
+++ b/src/components/ShortcutSheet.tsx
@@ -14,6 +14,8 @@ const SHORTCUTS: { keys: string; what: string }[] = [
   { keys: "⌘1 … ⌘9", what: "Go to a tab by position" },
   { keys: "⌘[ / ⌘]", what: "Back and forward through the trail" },
   { keys: "⌘-click", what: "Open a row in a tab of its own" },
+  { keys: "⌘+ / ⌘−", what: "Make the interface larger or smaller" },
+  { keys: "⌘0", what: "Back to the standard size" },
   { keys: "Esc", what: "Close the palette, or go back" },
   { keys: "?", what: "Show this list" },
 ];

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Sidebar } from "./Sidebar";
-import { api, type ApiResourceInfo, type ClusterInfo } from "../lib/api";
+import { api, type ApiResourceInfo } from "../lib/api";
 
 vi.mock("../lib/api", async (original) => {
   const actual = await original<typeof import("../lib/api")>();
@@ -36,72 +36,26 @@ const CRDS = [
   resource("", "Pod", false),
 ];
 
-const CLUSTER: ClusterInfo = {
-  context: "orbstack",
-  server: "https://127.0.0.1:26443",
-  version: "v1.34.8",
-  platform: "darwin/arm64",
-};
-
 function setup({
-  cluster = CLUSTER as ClusterInfo | null,
-  view = { type: "nodes" } as Parameters<typeof Sidebar>[0]["view"],
-  guard = "open" as Parameters<typeof Sidebar>[0]["guard"],
+  route = { type: "nodes" } as Parameters<typeof Sidebar>[0]["route"],
 } = {}) {
   listApiResources.mockResolvedValue(CRDS);
   const onSelect = vi.fn();
-  const onGuardChange = vi.fn();
 
   render(
     <QueryClientProvider
       client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
     >
       <Sidebar
-        cluster={cluster}
-        view={view}
+        route={route}
         onSelect={onSelect}
         theme="system"
         onThemeChange={vi.fn()}
-        guard={guard}
-        onGuardChange={onGuardChange}
-        onSwitchCluster={vi.fn()}
-        onDisconnect={vi.fn()}
       />
     </QueryClientProvider>,
   );
-  return { onSelect, onGuardChange, user: userEvent.setup() };
+  return { onSelect, user: userEvent.setup() };
 }
-
-// The guard is only worth having if it is visible. These assert that a
-// marked cluster is legible from the rail — including in a screenshot,
-// which is where most people will first see that this exists.
-describe("Sidebar guard", () => {
-  it("says nothing extra about an ordinary cluster", () => {
-    setup({ guard: "open" });
-    expect(screen.queryByText("Read-only")).not.toBeInTheDocument();
-    expect(screen.queryByText("Protected")).not.toBeInTheDocument();
-  });
-
-  it("marks a read-only cluster where the version usually sits", () => {
-    setup({ guard: "readOnly" });
-    expect(screen.getByText("Read-only")).toBeInTheDocument();
-  });
-
-  it("marks a protected cluster", () => {
-    setup({ guard: "protected" });
-    expect(screen.getByText("Protected")).toBeInTheDocument();
-  });
-
-  it("changes the guard from the rail", async () => {
-    const { user, onGuardChange } = setup({ guard: "open" });
-
-    await user.selectOptions(
-      screen.getByRole("combobox", { name: /What this context allows/ }),
-      "readOnly",
-    );
-    expect(onGuardChange).toHaveBeenCalledWith("readOnly");
-  });
-});
 
 beforeEach(() => {
   listApiResources.mockReset();
@@ -129,7 +83,7 @@ describe("Sidebar CRDs section", () => {
     expect(screen.getByText("monitoring.coreos.com")).toBeInTheDocument();
   });
 
-  it("selects a kind and switches the view to it", async () => {
+  it("selects a kind and navigates to it", async () => {
     const { user, onSelect } = setup();
     await screen.findByText("3");
     await user.click(screen.getByRole("button", { name: "Expand CRDs" }));
@@ -151,7 +105,7 @@ describe("Sidebar CRDs section", () => {
     // Reaching a CRD from the index table should not leave the rail
     // shut over the thing that is on screen.
     setup({
-      view: {
+      route: {
         type: "kind",
         entry: { id: "krypton.ai/v1/Agent", label: "Agent", gvk: CRDS[0] },
       },
@@ -173,7 +127,7 @@ describe("Sidebar CRDs section", () => {
     expect(screen.getByText("Storage")).toBeInTheDocument();
   });
 
-  it("reports a fixed kind as a kind view", async () => {
+  it("reports a fixed kind as a kind route", async () => {
     const { user, onSelect } = setup();
     await user.click(screen.getByRole("button", { name: "Services" }));
     expect(onSelect).toHaveBeenCalledWith({
@@ -182,13 +136,7 @@ describe("Sidebar CRDs section", () => {
     });
   });
 
-  it("does not reach for the cluster before there is one", () => {
-    setup({ cluster: null });
-    expect(listApiResources).not.toHaveBeenCalled();
-    expect(screen.getByRole("button", { name: /^CRDs/ })).toBeDisabled();
-  });
-
-  it("collapses again without changing the view", async () => {
+  it("collapses again without navigating", async () => {
     const { user, onSelect } = setup();
     await screen.findByText("3");
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,28 +5,27 @@ import { dragRegionProps } from "../lib/window";
 import { KIND_SECTIONS, type KindEntry } from "../lib/kinds";
 import { ThemePicker } from "./ThemePicker";
 import type { Theme } from "../lib/theme";
-import { Select } from "./Select";
 import { ForwardsPanel } from "./Forwards";
-import { api, type ApiResourceInfo, type ClusterInfo, type Guard } from "../lib/api";
+import { api, type ApiResourceInfo } from "../lib/api";
+import type { Route } from "../lib/routes";
 
-/// Which pane the main area is showing.
-///
-/// `kind` covers everything driven by a server-printed table — the
-/// sidebar's workloads, networking, config and storage entries, and any
-/// custom resource picked from the CRDs section. The rest have views
-/// with more than a table behind them.
-export type View =
-  | { type: "nodes" }
-  | { type: "namespaces" }
-  | { type: "pods" }
-  | { type: "crds" }
-  | { type: "helm" }
-  | { type: "kind"; entry: KindEntry };
+// The rail: where you go, not what you are connected to.
+//
+// The cluster chip, its guard and the disconnect button used to live in
+// the foot of this list. They describe the session rather than a
+// destination, and a reader three panes deep into a manifest has no
+// reason to look back at the navigation to find out which cluster they
+// are about to write to — so they are in the status bar now.
 
 // Each resource gets a mark rather than an icon font. The references
 // that read well all use colour to make the left rail scannable — you
 // learn the shape and stop reading the label.
-type Item = { id: View["type"]; label: string; tint: string; glyph: string };
+type Item = {
+  id: "nodes" | "namespaces" | "pods" | "helm";
+  label: string;
+  tint: string;
+  glyph: string;
+};
 
 const CLUSTER_ITEMS: Item[] = [
   { id: "nodes", label: "Nodes", tint: "text-info", glyph: "▤" },
@@ -39,45 +38,16 @@ const HELM: Item = { id: "helm", label: "Helm", tint: "text-info", glyph: "⎈" 
 const CRD_MARK = { tint: "text-warn", glyph: "❖" };
 
 interface SidebarProps {
-  cluster: ClusterInfo | null;
-  view: View;
-  onSelect: (v: View) => void;
+  /// What the active tab is showing, so the rail can mark it.
+  route: Route;
+  onSelect: (route: Route) => void;
   theme: Theme;
   onThemeChange: (theme: Theme) => void;
-  /// What the connected context allows, and how to change it. Shown
-  /// beside the cluster name rather than buried in a settings screen:
-  /// the whole value of the safeguard is that it is legible at a glance,
-  /// and in a screenshot.
-  guard: Guard;
-  onGuardChange: (guard: Guard) => void;
-  onSwitchCluster: () => void;
-  onDisconnect: () => void;
 }
 
-/// How each guard reads in the rail.
-const GUARD_LABEL: Record<Guard, string> = {
-  open: "Writable",
-  protected: "Protected",
-  readOnly: "Read-only",
-};
-
-const GUARD_TONE: Record<Guard, string> = {
-  open: "text-content-muted",
-  protected: "text-warn",
-  readOnly: "text-danger",
-};
-
-/// The dot beside the cluster name. Green for an ordinary cluster, and
-/// something you cannot miss for one you have marked.
-const GUARD_DOT: Record<Guard, string> = {
-  open: "bg-success shadow-[0_0_0_3px_rgb(var(--success)/0.15)]",
-  protected: "bg-warn shadow-[0_0_0_3px_rgb(var(--warn)/0.15)]",
-  readOnly: "bg-danger shadow-[0_0_0_3px_rgb(var(--danger)/0.15)]",
-};
-
-/// The kind a `kind` view is showing, or null for anything else.
-function selectedKindId(view: View) {
-  return view.type === "kind" ? view.entry.id : null;
+/// The kind a `kind` route is showing, or null for anything else.
+function selectedKindId(route: Route) {
+  return route.type === "kind" ? route.entry.id : null;
 }
 
 /// A nav row for one kind, at the indent the sections use.
@@ -126,16 +96,14 @@ function itemClass(active: boolean) {
 function NavItem({
   item,
   active,
-  disabled,
   onSelect,
 }: {
   item: Item;
   active: boolean;
-  disabled: boolean;
   onSelect: () => void;
 }) {
   return (
-    <button onClick={onSelect} disabled={disabled} className={itemClass(active)}>
+    <button onClick={onSelect} className={itemClass(active)}>
       <span
         aria-hidden
         className={`w-3.5 text-center text-xs ${active ? item.tint : "text-content-muted group-hover:" + item.tint}`}
@@ -157,13 +125,11 @@ function NavItem({
 /// already in the sections above, and the rest are on the index page.
 function CrdSection({
   selectedId,
-  enabled,
   onOpenIndex,
   onSelectKind,
   indexActive,
 }: {
   selectedId: string | null;
-  enabled: boolean;
   onOpenIndex: () => void;
   onSelectKind: (entry: KindEntry) => void;
   indexActive: boolean;
@@ -176,7 +142,6 @@ function CrdSection({
     // Shared with the index page, and the API surface only changes when
     // someone installs a CRD — not worth rediscovering per mount.
     staleTime: 5 * 60 * 1000,
-    enabled,
   });
 
   const crds: { entry: KindEntry; resource: ApiResourceInfo }[] = (q.data ?? [])
@@ -207,7 +172,6 @@ function CrdSection({
             setOpen(true);
             onOpenIndex();
           }}
-          disabled={!enabled}
           className={`${itemClass(indexActive)} mb-0 flex-1`}
         >
           <span
@@ -228,7 +192,7 @@ function CrdSection({
             to the index are not the same click. */}
         <button
           onClick={() => setOpen((o) => !o)}
-          disabled={!enabled || crds.length === 0}
+          disabled={crds.length === 0}
           aria-expanded={open}
           aria-label={open ? "Collapse CRDs" : "Expand CRDs"}
           className="ml-0.5 rounded px-1.5 text-2xs text-content-muted transition-colors hover:bg-content/[0.05] hover:text-content disabled:opacity-0"
@@ -275,17 +239,12 @@ function CrdSection({
 }
 
 export function Sidebar({
-  cluster,
-  view,
+  route,
   onSelect,
   theme,
   onThemeChange,
-  guard,
-  onGuardChange,
-  onSwitchCluster,
-  onDisconnect,
 }: SidebarProps) {
-  const selectedId = selectedKindId(view);
+  const selectedId = selectedKindId(route);
 
   return (
     <aside className="glass flex w-60 shrink-0 flex-col border-r">
@@ -307,9 +266,8 @@ export function Sidebar({
           <NavItem
             key={item.id}
             item={item}
-            active={view.type === item.id}
-            disabled={!cluster}
-            onSelect={() => onSelect({ type: item.id } as View)}
+            active={route.type === item.id}
+            onSelect={() => onSelect({ type: item.id })}
           />
         ))}
 
@@ -332,81 +290,26 @@ export function Sidebar({
         <SectionLabel>Extensions</SectionLabel>
         <CrdSection
           selectedId={selectedId}
-          indexActive={view.type === "crds"}
-          enabled={cluster != null}
+          indexActive={route.type === "crds"}
           onOpenIndex={() => onSelect({ type: "crds" })}
           onSelectKind={(entry) => onSelect({ type: "kind", entry })}
         />
 
         <NavItem
           item={HELM}
-          active={view.type === "helm"}
-          disabled={!cluster}
+          active={route.type === "helm"}
           onSelect={() => onSelect({ type: "helm" })}
         />
       </nav>
 
       {/* Above the theme picker: a running forward is state the user is
           holding, and it belongs where they will notice it. */}
-      {cluster && <ForwardsPanel />}
+      <ForwardsPanel />
 
       <div className="border-t p-2">
         <ThemePicker theme={theme} onChange={onThemeChange} />
       </div>
 
-      {cluster && (
-        <div className="border-t p-2">
-          {/* The cluster chip doubles as the context switcher — the
-              thing people reach for most after picking the wrong one. */}
-          <button
-            onClick={onSwitchCluster}
-            title={`${cluster.server}\nClick to switch cluster`}
-            className="group flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition-colors duration-150 ease-swift hover:bg-content/[0.05]"
-          >
-            <span
-              className={`h-1.5 w-1.5 shrink-0 rounded-full ${GUARD_DOT[guard]}`}
-            />
-            <span className="min-w-0 flex-1">
-              <span className="block truncate text-xs font-medium">
-                {cluster.context}
-              </span>
-              <span className="block truncate text-2xs text-content-muted">
-                {guard === "open" ? (
-                  cluster.version
-                ) : (
-                  // Replaces the version rather than sitting beside it:
-                  // on a cluster you have marked, this is the thing
-                  // worth reading.
-                  <span className={GUARD_TONE[guard]}>{GUARD_LABEL[guard]}</span>
-                )}
-              </span>
-            </span>
-            <span className="shrink-0 text-xs text-content-muted transition-colors group-hover:text-content-secondary">
-              ⇄
-            </span>
-          </button>
-
-          <div className="mt-1 flex items-center gap-1.5 px-2">
-            <span className="shrink-0 text-2xs text-content-muted">Writes</span>
-            <Select
-              value={guard}
-              onChange={(v) => onGuardChange(v as Guard)}
-              title="What this context allows. Loupe's own safeguard, not RBAC — it does not change your permissions."
-            >
-              <option value="open">Allowed</option>
-              <option value="protected">Confirm each</option>
-              <option value="readOnly">Refused</option>
-            </Select>
-          </div>
-
-          <button
-            onClick={onDisconnect}
-            className="mt-1 w-full rounded px-2 py-1 text-left text-2xs text-content-muted transition-colors hover:bg-content/[0.05] hover:text-content-secondary"
-          >
-            Disconnect
-          </button>
-        </div>
-      )}
     </aside>
   );
 }

--- a/src/components/StatusBar.test.tsx
+++ b/src/components/StatusBar.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StatusBar } from "./StatusBar";
+import type { ClusterInfo, Guard } from "../lib/api";
+
+// The guard is only worth having if it is impossible to miss. It used to
+// sit in the foot of the nav rail; these assert it is legible from the
+// status bar instead — including in a screenshot, which is where most
+// people will first see that this exists.
+
+const CLUSTER: ClusterInfo = {
+  context: "prod-eu-west-1",
+  server: "https://10.0.0.1:6443",
+  version: "v1.34.8",
+  platform: "linux/amd64",
+};
+
+function setup(guard: Guard = "open") {
+  const onGuardChange = vi.fn();
+  const onSwitchCluster = vi.fn();
+  const onDisconnect = vi.fn();
+
+  render(
+    <StatusBar
+      cluster={CLUSTER}
+      guard={guard}
+      onGuardChange={onGuardChange}
+      onSwitchCluster={onSwitchCluster}
+      onDisconnect={onDisconnect}
+    />,
+  );
+  return {
+    onGuardChange,
+    onSwitchCluster,
+    onDisconnect,
+    user: userEvent.setup(),
+  };
+}
+
+describe("StatusBar", () => {
+  it("names the cluster and its version", () => {
+    setup();
+    expect(screen.getByText("prod-eu-west-1")).toBeInTheDocument();
+    expect(screen.getByText("v1.34.8")).toBeInTheDocument();
+  });
+
+  it("says an ordinary cluster is writable without shouting", () => {
+    setup("open");
+    expect(screen.getByText("Writes allowed")).toBeInTheDocument();
+    expect(screen.queryByText("Read-only")).not.toBeInTheDocument();
+  });
+
+  it("marks a read-only cluster", () => {
+    setup("readOnly");
+    expect(screen.getByText("Read-only")).toBeInTheDocument();
+  });
+
+  it("marks a protected cluster", () => {
+    setup("protected");
+    expect(screen.getByText(/Protected/)).toBeInTheDocument();
+  });
+
+  it("takes the guard's colour, so a marked cluster reads differently", () => {
+    // The point of the safeguard is that you notice it without looking
+    // for it. A tint across the whole line does that; a word does not.
+    const { container } = render(
+      <StatusBar
+        cluster={CLUSTER}
+        guard="readOnly"
+        onGuardChange={vi.fn()}
+        onSwitchCluster={vi.fn()}
+        onDisconnect={vi.fn()}
+      />,
+    );
+    expect(container.querySelector("footer")?.className).toContain("bg-danger");
+  });
+
+  it("changes the guard", async () => {
+    const { user, onGuardChange } = setup("open");
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: /What this context allows/ }),
+      "readOnly",
+    );
+    expect(onGuardChange).toHaveBeenCalledWith("readOnly");
+  });
+
+  it("switches cluster from the cluster name", async () => {
+    // The thing people reach for most after picking the wrong one.
+    const { user, onSwitchCluster } = setup();
+    await user.click(screen.getByText("prod-eu-west-1"));
+    expect(onSwitchCluster).toHaveBeenCalledOnce();
+  });
+
+  it("disconnects", async () => {
+    const { user, onDisconnect } = setup();
+    await user.click(screen.getByRole("button", { name: "Disconnect" }));
+    expect(onDisconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,0 +1,104 @@
+import { Select } from "./Select";
+import type { ClusterInfo, Guard } from "../lib/api";
+
+// The line along the bottom of the window.
+//
+// What it holds is the answer to "what am I connected to, and what will
+// it let me do" — the two questions whose answer has to be true no
+// matter how many panes deep you are. Previously they lived in the foot
+// of the nav rail, which is navigation space, and which a reader has no
+// reason to look at once they are reading an object.
+//
+// It spans the whole window rather than the main area, because it
+// describes the session and not the tab.
+
+const GUARD_LABEL: Record<Guard, string> = {
+  open: "Writes allowed",
+  protected: "Protected · writes confirm",
+  readOnly: "Read-only",
+};
+
+const GUARD_TONE: Record<Guard, string> = {
+  open: "text-content-secondary",
+  protected: "text-warn font-medium",
+  readOnly: "text-danger font-medium",
+};
+
+const GUARD_DOT: Record<Guard, string> = {
+  open: "bg-success",
+  protected: "bg-warn",
+  readOnly: "bg-danger",
+};
+
+/// The bar takes the guard's colour, so a cluster you have marked reads
+/// differently at a glance and in a screenshot.
+const GUARD_WASH: Record<Guard, string> = {
+  open: "",
+  protected: "bg-warn/[0.08]",
+  readOnly: "bg-danger/[0.08]",
+};
+
+const CELL = "flex shrink-0 items-center gap-2 border-r px-3 py-1";
+
+interface StatusBarProps {
+  cluster: ClusterInfo;
+  guard: Guard;
+  onGuardChange: (guard: Guard) => void;
+  onSwitchCluster: () => void;
+  onDisconnect: () => void;
+}
+
+export function StatusBar({
+  cluster,
+  guard,
+  onGuardChange,
+  onSwitchCluster,
+  onDisconnect,
+}: StatusBarProps) {
+  return (
+    <footer
+      className={`flex shrink-0 items-stretch border-t text-2xs text-content-secondary ${GUARD_WASH[guard]}`}
+    >
+      <button
+        onClick={onSwitchCluster}
+        title={`${cluster.server}\nClick to switch cluster`}
+        className={`${CELL} min-w-0 transition-colors duration-150 ease-swift hover:bg-content/[0.05]`}
+      >
+        <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${GUARD_DOT[guard]}`} />
+        <span className="truncate font-medium text-content">{cluster.context}</span>
+        <span aria-hidden className="text-content-muted">
+          ⇄
+        </span>
+      </button>
+
+      <span className={`${CELL} ${GUARD_TONE[guard]}`}>{GUARD_LABEL[guard]}</span>
+
+      <span className={CELL}>
+        <span className="text-content-muted">Writes</span>
+        <Select
+          dense
+          value={guard}
+          onChange={(v) => onGuardChange(v as Guard)}
+          title="What this context allows. Loupe's own safeguard, not RBAC — it does not change your permissions."
+        >
+          <option value="open">Allowed</option>
+          <option value="protected">Confirm each</option>
+          <option value="readOnly">Refused</option>
+        </Select>
+      </span>
+
+      {/* Everything after this sits at the far end, where a status bar
+          keeps the things you read rather than press. */}
+      <span className="min-w-0 flex-1" />
+
+      <span className={`${CELL} font-mono text-content-muted`}>{cluster.version}</span>
+
+      <button
+        onClick={onDisconnect}
+        className="shrink-0 px-3 py-1 text-content-muted transition-colors duration-150 ease-swift hover:bg-content/[0.05] hover:text-content"
+      >
+        Disconnect
+      </button>
+    </footer>
+  );
+}

--- a/src/components/TabStrip.tsx
+++ b/src/components/TabStrip.tsx
@@ -1,0 +1,89 @@
+import { routeLabel, routeTitle } from "../lib/routes";
+import type { Tab } from "../lib/workspace";
+import { dragRegionProps } from "../lib/window";
+
+// The tabs across the top of the main area.
+//
+// One tab is one piece of work: a listing you keep coming back to, an
+// object you are watching, a manifest you are part-way through reading.
+// Before this the app held exactly one view, so opening a pod lost the
+// list it came from and there was no way to hold a healthy replica
+// beside a failing one.
+//
+// This is the window's top edge on macOS, so it carries the drag region
+// and the padding that clears the traffic lights. Buttons inside opt
+// out, or a click meant for a tab would move the window instead.
+
+interface TabStripProps {
+  tabs: Tab[];
+  active: string;
+  onSelect: (id: string) => void;
+  onClose: (id: string) => void;
+  onNew: () => void;
+}
+
+export function TabStrip({
+  tabs,
+  active,
+  onSelect,
+  onClose,
+  onNew,
+}: TabStripProps) {
+  return (
+    <div
+      {...dragRegionProps}
+      role="tablist"
+      aria-label="Open tabs"
+      className="drag-region glass flex shrink-0 items-stretch border-b pt-9"
+    >
+      <div className="no-drag flex min-w-0 flex-1 items-stretch overflow-x-auto">
+        {tabs.map((tab) => {
+          const route = tab.history[tab.index];
+          const on = tab.id === active;
+          return (
+            <div
+              key={tab.id}
+              className={`group flex max-w-[13rem] shrink-0 items-center border-r transition-colors duration-150 ease-swift ${
+                on
+                  ? "bg-surface-1 shadow-[inset_0_2px_0_rgb(var(--accent))]"
+                  : "hover:bg-content/[0.04]"
+              }`}
+            >
+              <button
+                role="tab"
+                aria-selected={on}
+                title={routeTitle(route)}
+                onClick={() => onSelect(tab.id)}
+                className={`min-w-0 py-1.5 pl-3 pr-2 text-left text-xs ${
+                  on ? "font-medium text-content" : "text-content-secondary"
+                }`}
+              >
+                <span className="block truncate">{routeLabel(route)}</span>
+              </button>
+
+              {/* Always rendered rather than shown on hover: a control
+                  that appears under the pointer is one you cannot aim
+                  for, and the row is too short for the shift. */}
+              <button
+                onClick={() => onClose(tab.id)}
+                aria-label={`Close ${routeLabel(route)}`}
+                className="mr-1.5 rounded-sm px-1 text-2xs text-content-muted transition-colors hover:bg-content/[0.08] hover:text-content"
+              >
+                ×
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      <button
+        onClick={onNew}
+        aria-label="New tab"
+        title="New tab (⌘T)"
+        className="no-drag shrink-0 border-l px-3 text-sm text-content-muted transition-colors hover:bg-content/[0.05] hover:text-content"
+      >
+        +
+      </button>
+    </div>
+  );
+}

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -5,6 +5,7 @@
 // hundreds of rows and losing the column names on scroll is the single
 // most annoying thing a resource table can do.
 import type { ReactNode } from "react";
+import { intentOf, type OpenIntent } from "../lib/routes";
 
 export interface Column<T> {
   key: string;
@@ -24,7 +25,8 @@ interface TableProps<T> {
   /// repeated Kubernetes events can be identical in every field.
   rowKey: (row: T, index: number) => string;
   empty?: string;
-  onRowClick?: (row: T) => void;
+  /// The intent says whether the click asked for this tab or a new one.
+  onRowClick?: (row: T, intent: OpenIntent) => void;
 }
 
 export function Table<T>({
@@ -61,7 +63,7 @@ export function Table<T>({
         {rows.map((row, index) => (
           <tr
             key={rowKey(row, index)}
-            onClick={onRowClick ? () => onRowClick(row) : undefined}
+            onClick={onRowClick ? (e) => onRowClick(row, intentOf(e)) : undefined}
             // Rows are only focusable when they do something; a tab stop
             // that goes nowhere is worse than none.
             tabIndex={onRowClick ? 0 : undefined}
@@ -70,7 +72,7 @@ export function Table<T>({
                 ? (e) => {
                     if (e.key === "Enter" || e.key === " ") {
                       e.preventDefault();
-                      onRowClick(row);
+                      onRowClick(row, intentOf(e));
                     }
                   }
                 : undefined

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -6,6 +6,7 @@
 // most annoying thing a resource table can do.
 import type { ReactNode } from "react";
 import { intentOf, type OpenIntent } from "../lib/routes";
+import type { SortState, SortValue } from "../lib/sort";
 
 export interface Column<T> {
   key: string;
@@ -16,6 +17,10 @@ export interface Column<T> {
   mono?: boolean;
   /// Keeps a column from being squeezed by a long neighbour.
   width?: string;
+  /// What this column sorts on. A column without one is not sortable:
+  /// `render` returns a React node, and sorting by that would order the
+  /// table by markup rather than by meaning.
+  sortValue?: (row: T) => SortValue;
 }
 
 interface TableProps<T> {
@@ -27,7 +32,17 @@ interface TableProps<T> {
   empty?: string;
   /// The intent says whether the click asked for this tab or a new one.
   onRowClick?: (row: T, intent: OpenIntent) => void;
+  /// Which column the rows arrived sorted by, and how. Null means the
+  /// order the server sent. Omitting `onSort` leaves every header inert,
+  /// which is what the small fixed tables inside a detail view want.
+  sort?: SortState | null;
+  onSort?: (key: string) => void;
 }
+
+/// How the active column's arrow reads. Both directions get a glyph
+/// rather than only one, so the header says which way it is sorted
+/// instead of only that it is.
+const ARROW: Record<"asc" | "desc", string> = { asc: "↑", desc: "↓" };
 
 export function Table<T>({
   columns,
@@ -35,6 +50,8 @@ export function Table<T>({
   rowKey,
   empty,
   onRowClick,
+  sort = null,
+  onSort,
 }: TableProps<T>) {
   if (rows.length === 0) {
     return (
@@ -48,15 +65,60 @@ export function Table<T>({
     <table className="w-full border-collapse text-sm">
       <thead className="sticky top-0 z-10">
         <tr className="glass text-left">
-          {columns.map((c) => (
-            <th
-              key={c.key}
-              style={c.width ? { width: c.width } : undefined}
-              className="whitespace-nowrap border-b px-4 py-2 text-2xs font-medium uppercase tracking-wide text-content-muted"
-            >
-              {c.header}
-            </th>
-          ))}
+          {columns.map((c) => {
+            const sortable = onSort != null && c.sortValue != null;
+            const active = sortable && sort?.key === c.key;
+            return (
+              <th
+                key={c.key}
+                style={c.width ? { width: c.width } : undefined}
+                // Announced so a screen reader gets the same information
+                // the arrow gives everyone else.
+                aria-sort={
+                  active
+                    ? sort!.direction === "asc"
+                      ? "ascending"
+                      : "descending"
+                    : sortable
+                      ? "none"
+                      : undefined
+                }
+                className="whitespace-nowrap border-b p-0 text-2xs font-medium uppercase tracking-wide text-content-muted"
+              >
+                {sortable ? (
+                  <button
+                    onClick={() => onSort(c.key)}
+                    // The header is a drag handle's neighbour and a
+                    // click target; the title says what the next click
+                    // will do rather than what the last one did.
+                    title={
+                      active && sort!.direction === "asc"
+                        ? `Sort by ${c.header}, descending`
+                        : active
+                          ? `Stop sorting by ${c.header}`
+                          : `Sort by ${c.header}`
+                    }
+                    className={`flex w-full items-center gap-1 px-4 py-2 text-left uppercase tracking-wide transition-colors duration-150 ease-swift hover:bg-content/[0.05] hover:text-content ${
+                      active ? "text-content" : ""
+                    }`}
+                  >
+                    {c.header}
+                    {/* The slot is held whether or not this column is
+                        the sorted one, so turning a sort on does not
+                        shove every other header sideways. */}
+                    <span
+                      aria-hidden
+                      className={active ? "text-accent" : "opacity-0"}
+                    >
+                      {ARROW[active ? sort!.direction : "asc"]}
+                    </span>
+                  </button>
+                ) : (
+                  <span className="block px-4 py-2">{c.header}</span>
+                )}
+              </th>
+            );
+          })}
         </tr>
       </thead>
       <tbody>

--- a/src/components/TableBrowser.tsx
+++ b/src/components/TableBrowser.tsx
@@ -6,6 +6,7 @@ import { type Column } from "./Table";
 import { Select } from "./Select";
 import { StatusDot } from "./StatusDot";
 import { api, type GvkRef, type TableRow } from "../lib/api";
+import type { OpenIntent } from "../lib/routes";
 import { useWatch } from "../lib/useWatch";
 import { statusTone } from "../pages/ObjectDetail";
 
@@ -41,7 +42,7 @@ interface TableBrowserProps {
   title: string;
   /// Rendered under the title — the API group, usually.
   subtitle?: string;
-  onOpen: (row: TableRow) => void;
+  onOpen: (row: TableRow, intent: OpenIntent) => void;
   /// Extra controls for the panel header.
   actions?: React.ReactNode;
 }

--- a/src/components/TableBrowser.tsx
+++ b/src/components/TableBrowser.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { Panel } from "./Panel";
 import { ResourceTable } from "./ResourceTable";
@@ -6,7 +6,7 @@ import { type Column } from "./Table";
 import { Select } from "./Select";
 import { StatusDot } from "./StatusDot";
 import { api, type GvkRef, type TableRow } from "../lib/api";
-import type { OpenIntent } from "../lib/routes";
+import type { ListView, OpenIntent } from "../lib/routes";
 import { useWatch } from "../lib/useWatch";
 import { statusTone } from "../pages/ObjectDetail";
 
@@ -45,6 +45,10 @@ interface TableBrowserProps {
   onOpen: (row: TableRow, intent: OpenIntent) => void;
   /// Extra controls for the panel header.
   actions?: React.ReactNode;
+  /// How this listing is presented, held by the caller so it survives
+  /// opening a row and coming back.
+  view: ListView;
+  onView: (patch: Partial<ListView>) => void;
 }
 
 export function TableBrowser({
@@ -53,12 +57,16 @@ export function TableBrowser({
   subtitle,
   onOpen,
   actions,
+  view,
+  onView,
 }: TableBrowserProps) {
-  const [namespace, setNamespace] = useState("");
+  const namespace = view.namespace ?? "";
+  const setNamespace = (next: string) => onView({ namespace: next });
   // Kubectl calls these `-o wide`. Off by default for the same reason:
   // Selector and Images columns are long enough to squeeze everything
   // else off a narrow pane.
-  const [wide, setWide] = useState(false);
+  const wide = view.wide ?? false;
+  const setWide = (next: boolean) => onView({ wide: next });
 
   // Fetched a page at a time. Asking for everything meant a busy cluster
   // pulled 20,000 objects across the IPC boundary before the first fifty
@@ -182,10 +190,16 @@ export function TableBrowser({
         remaining={lastPage?.remaining ?? null}
         loadingMore={q.isFetchingNextPage}
         onLoadMore={() => q.fetchNextPage()}
+        view={view}
+        onView={onView}
         toolbar={
           <>
             {table?.namespaced && (
-              <Select value={namespace} onChange={setNamespace}>
+              <Select
+                title="Namespace"
+                value={namespace}
+                onChange={setNamespace}
+              >
                 <option value="">All namespaces</option>
                 {(namespaces.data ?? []).map((ns) => (
                   <option key={ns.name} value={ns.name}>

--- a/src/components/TableBrowser.tsx
+++ b/src/components/TableBrowser.tsx
@@ -100,7 +100,7 @@ export function TableBrowser({
       .map((column, index) => ({ column, index }))
       .filter(({ column }) => wide || column.priority === 0);
 
-    const cells = visible.map(({ column, index }) => {
+    const cells: Column<TableRow>[] = visible.map(({ column, index }) => {
       const status = STATUS_COLUMNS.has(column.name.toLowerCase());
       return {
         key: `${index}`,
@@ -119,6 +119,12 @@ export function TableBrowser({
           );
         },
         mono: !status && /age|ports?|ip|capacity|size|version/i.test(column.name),
+        // The raw cell, not the rendered one. Every value here is a
+        // string the server printed, so the comparator does the reading:
+        // an AGE of "65d" against "10m", a READY of "0/1" against "1/1",
+        // a RESTARTS of "12" against "2" all order by what they mean
+        // rather than by how they happen to spell it.
+        sortValue: (row: TableRow) => row.cells[index],
       } satisfies Column<TableRow>;
     });
 
@@ -130,6 +136,7 @@ export function TableBrowser({
         header: "Namespace",
         render: (row: TableRow) => row.namespace ?? "—",
         mono: false,
+        sortValue: (row: TableRow) => row.namespace,
       });
     }
     return cells;

--- a/src/components/TrailBar.tsx
+++ b/src/components/TrailBar.tsx
@@ -1,0 +1,95 @@
+import { routeLabel, routeTitle, type Route } from "../lib/routes";
+
+// Back, forward, and the path that got you here.
+//
+// The crumbs are the tab's own history, not a hierarchy invented for
+// display: from a pod you reach its ReplicaSet, from there the
+// Deployment above it, and from there the Service that selects it —
+// none of which is a containment tree, and all of which is the route
+// you actually took. Clicking a crumb walks back to it without
+// discarding what is ahead, so the trip is reversible in both
+// directions.
+//
+// Rendered only once a tab has somewhere to go back to. At the top of a
+// tab there is no path, and a bar showing one disabled arrow is chrome
+// paying no rent.
+
+interface TrailBarProps {
+  trail: Route[];
+  canBack: boolean;
+  canForward: boolean;
+  onBack: () => void;
+  onForward: () => void;
+  onCrumb: (index: number) => void;
+}
+
+const ARROW =
+  "rounded-sm px-1.5 text-xs transition-colors duration-150 ease-swift disabled:opacity-30 enabled:hover:bg-content/[0.06] enabled:hover:text-content";
+
+export function TrailBar({
+  trail,
+  canBack,
+  canForward,
+  onBack,
+  onForward,
+  onCrumb,
+}: TrailBarProps) {
+  const last = trail.length - 1;
+
+  return (
+    <nav
+      aria-label="Trail"
+      className="flex shrink-0 items-center gap-1 border-b px-3 py-1.5 text-content-muted"
+    >
+      <button
+        onClick={onBack}
+        disabled={!canBack}
+        aria-label="Back"
+        title="Back (⌘[)"
+        className={ARROW}
+      >
+        ←
+      </button>
+      <button
+        onClick={onForward}
+        disabled={!canForward}
+        aria-label="Forward"
+        title="Forward (⌘])"
+        className={ARROW}
+      >
+        →
+      </button>
+
+      <ol className="ml-1 flex min-w-0 items-center gap-1 text-2xs">
+        {trail.map((route, i) => (
+          <li key={i} className="flex min-w-0 items-center gap-1">
+            {i > 0 && (
+              <span aria-hidden className="text-content-muted/60">
+                ›
+              </span>
+            )}
+            {i === last ? (
+              // Where you are. Not a button: there is nowhere for it to
+              // go, and offering the click implies otherwise.
+              <span
+                aria-current="page"
+                title={routeTitle(route)}
+                className="truncate font-medium text-content"
+              >
+                {routeLabel(route)}
+              </span>
+            ) : (
+              <button
+                onClick={() => onCrumb(i)}
+                title={`Back to ${routeTitle(route)}`}
+                className="truncate rounded-sm px-1 transition-colors hover:bg-content/[0.06] hover:text-content"
+              >
+                {routeLabel(route)}
+              </button>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/TrailBar.tsx
+++ b/src/components/TrailBar.tsx
@@ -1,44 +1,39 @@
-import { routeLabel, routeTitle, type Route } from "../lib/routes";
+import type { Crumb, Route } from "../lib/routes";
 
-// Back, forward, and the path that got you here.
+// Back, forward, and where the thing on screen sits.
 //
-// The crumbs are the tab's own history, not a hierarchy invented for
-// display: from a pod you reach its ReplicaSet, from there the
-// Deployment above it, and from there the Service that selects it —
-// none of which is a containment tree, and all of which is the route
-// you actually took. Clicking a crumb walks back to it without
-// discarding what is ahead, so the trip is reversible in both
-// directions.
+// The crumbs are derived from the current route alone — a DaemonSet
+// shows "DaemonSets › monitoring › prom-node-exporter" wherever you
+// came from. They used to be the tab's visited history, which read
+// "Nodes › Pods › some-pod › Jobs › DaemonSets › some-daemonset": a
+// record of wandering, dressed up as a hierarchy it does not have.
 //
-// Rendered only once a tab has somewhere to go back to. At the top of a
-// tab there is no path, and a bar showing one disabled arrow is chrome
-// paying no rent.
+// Where you have been is a different question, and the arrows already
+// answer it. Keeping the two apart means each says one true thing.
 
 interface TrailBarProps {
-  trail: Route[];
+  crumbs: Crumb[];
   canBack: boolean;
   canForward: boolean;
   onBack: () => void;
   onForward: () => void;
-  onCrumb: (index: number) => void;
+  onCrumb: (route: Route) => void;
 }
 
 const ARROW =
   "rounded-sm px-1.5 text-xs transition-colors duration-150 ease-swift disabled:opacity-30 enabled:hover:bg-content/[0.06] enabled:hover:text-content";
 
 export function TrailBar({
-  trail,
+  crumbs,
   canBack,
   canForward,
   onBack,
   onForward,
   onCrumb,
 }: TrailBarProps) {
-  const last = trail.length - 1;
-
   return (
     <nav
-      aria-label="Trail"
+      aria-label="Breadcrumb"
       className="flex shrink-0 items-center gap-1 border-b px-3 py-1.5 text-content-muted"
     >
       <button
@@ -61,31 +56,31 @@ export function TrailBar({
       </button>
 
       <ol className="ml-1 flex min-w-0 items-center gap-1 text-2xs">
-        {trail.map((route, i) => (
+        {crumbs.map((crumb, i) => (
           <li key={i} className="flex min-w-0 items-center gap-1">
             {i > 0 && (
               <span aria-hidden className="text-content-muted/60">
                 ›
               </span>
             )}
-            {i === last ? (
+            {crumb.route ? (
+              <button
+                onClick={() => onCrumb(crumb.route!)}
+                title={`Go to ${crumb.title}`}
+                className="truncate rounded-sm px-1 transition-colors hover:bg-content/[0.06] hover:text-content"
+              >
+                {crumb.label}
+              </button>
+            ) : (
               // Where you are. Not a button: there is nowhere for it to
               // go, and offering the click implies otherwise.
               <span
                 aria-current="page"
-                title={routeTitle(route)}
+                title={crumb.title}
                 className="truncate font-medium text-content"
               >
-                {routeLabel(route)}
+                {crumb.label}
               </span>
-            ) : (
-              <button
-                onClick={() => onCrumb(i)}
-                title={`Back to ${routeTitle(route)}`}
-                className="truncate rounded-sm px-1 transition-colors hover:bg-content/[0.06] hover:text-content"
-              >
-                {routeLabel(route)}
-              </button>
             )}
           </li>
         ))}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -314,6 +314,8 @@ export interface RelatedObject {
 /// survive a cache clear and be a file the user can read or delete.
 export interface Settings {
   theme: Theme;
+  /// Interface scale, where 1 is the size the app is drawn at.
+  zoom: number;
   /// Contexts connected to, most recent first. Recorded by the backend
   /// on a successful connect.
   recentContexts: string[];
@@ -655,6 +657,9 @@ export const api = {
 
   getSettings: () => invoke<Settings>("get_settings"),
   setTheme: (theme: Theme) => invoke<Settings>("set_theme", { theme }),
+  /// Records the interface scale. Clamped by the backend, so a caller
+  /// cannot store a size the app has no way back from.
+  setZoom: (zoom: number) => invoke<Settings>("set_zoom", { zoom }),
   /// Pins or unpins a context in the picker, returning the settings as
   /// stored.
   setContextPinned: (context: string, pinned: boolean) =>

--- a/src/lib/routes.test.ts
+++ b/src/lib/routes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  crumbsFor,
   isDetail,
   parentOf,
   routeKey,
@@ -99,5 +100,114 @@ describe("parentOf", () => {
 
   it("gives a listing nothing to sit under", () => {
     expect(parentOf({ type: "pods" })).toBeNull();
+  });
+});
+
+describe("crumbsFor", () => {
+  /// Labels top to bottom, with the one you are standing on marked.
+  function crumbs(route: Route) {
+    return crumbsFor(route).map((c) => (c.route ? c.label : `[${c.label}]`));
+  }
+
+  it("puts an object under its kind and its namespace", () => {
+    expect(
+      crumbs({
+        type: "object",
+        resource: { group: "apps", version: "v1", kind: "DaemonSet" },
+        namespace: "monitoring",
+        name: "prom-node-exporter",
+      }),
+    ).toEqual(["DaemonSets", "monitoring", "[prom-node-exporter]"]);
+  });
+
+  it("says nothing about how you got there", () => {
+    // The bug this replaced: crumbs were the tab's visited history, so a
+    // DaemonSet reached by way of a pod and a job listing read
+    // "Nodes › Pods › some-pod › Jobs › DaemonSets › some-daemonset" —
+    // a record of wandering, implying a containment that is not real.
+    // The same object has the same crumbs however it was reached.
+    const route: Route = {
+      type: "object",
+      resource: { group: "apps", version: "v1", kind: "DaemonSet" },
+      namespace: "monitoring",
+      name: "prom-node-exporter",
+    };
+    expect(crumbs(route)).toHaveLength(3);
+  });
+
+  it("uses the rail's plural for a built-in kind", () => {
+    // "DaemonSets", the way the rail says it, rather than the API's
+    // singular "DaemonSet".
+    const [kind] = crumbsFor({
+      type: "object",
+      resource: { group: "apps", version: "v1", kind: "DaemonSet" },
+      namespace: "monitoring",
+      name: "x",
+    });
+    expect(kind.label).toBe("DaemonSets");
+    expect(kind.route).toEqual({
+      type: "kind",
+      entry: expect.objectContaining({ id: "apps/v1/DaemonSet" }),
+    });
+  });
+
+  it("falls back to the bare kind for a custom resource", () => {
+    const [kind] = crumbsFor({
+      type: "object",
+      resource: { group: "krypton.ai", version: "v1alpha1", kind: "Agent" },
+      namespace: "agents",
+      name: "mcp-hello",
+    });
+    expect(kind.label).toBe("Agent");
+  });
+
+  it("leaves out the namespace for a cluster-scoped object", () => {
+    expect(
+      crumbs({
+        type: "object",
+        resource: { group: "", version: "v1", kind: "PersistentVolume" },
+        namespace: null,
+        name: "pv-1",
+      }),
+      // "Volumes" because PersistentVolume is in the rail; the point
+      // here is the missing namespace crumb, not the label.
+    ).toEqual(["Volumes", "[pv-1]"]);
+  });
+
+  it("puts a pod under Pods and its namespace", () => {
+    expect(crumbs({ type: "pod", namespace: "prod", name: "web-abc" })).toEqual([
+      "Pods",
+      "prod",
+      "[web-abc]",
+    ]);
+  });
+
+  it("puts a node under Nodes, which has no namespace", () => {
+    expect(crumbs({ type: "node", name: "worker-1" })).toEqual([
+      "Nodes",
+      "[worker-1]",
+    ]);
+  });
+
+  it("puts a release under Helm", () => {
+    expect(
+      crumbs({ type: "release", namespace: "monitoring", name: "prom" }),
+    ).toEqual(["Helm", "monitoring", "[prom]"]);
+  });
+
+  it("gives a listing one crumb, because nothing sits above it", () => {
+    expect(crumbs({ type: "pods" })).toEqual(["[Pods]"]);
+    expect(crumbs({ type: "kind", entry })).toEqual(["[Deployments]"]);
+  });
+
+  it("never makes the last crumb a link", () => {
+    for (const route of [
+      { type: "pods" } as Route,
+      { type: "pod", namespace: "a", name: "b" } as Route,
+      { type: "node", name: "n" } as Route,
+    ]) {
+      const all = crumbsFor(route);
+      expect(all[all.length - 1].route).toBeNull();
+    }
   });
 });

--- a/src/lib/routes.test.ts
+++ b/src/lib/routes.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  isDetail,
+  parentOf,
+  routeKey,
+  routeLabel,
+  routeTitle,
+  type Route,
+} from "./routes";
+
+const entry = {
+  id: "apps/v1/Deployment",
+  label: "Deployments",
+  gvk: { group: "apps", version: "v1", kind: "Deployment" },
+};
+
+describe("routeKey", () => {
+  it("is the same for two routes naming the same destination", () => {
+    const a: Route = { type: "pod", namespace: "kube-system", name: "coredns" };
+    const b: Route = { type: "pod", namespace: "kube-system", name: "coredns" };
+    expect(routeKey(a)).toBe(routeKey(b));
+  });
+
+  it("separates the same name in two namespaces", () => {
+    const a: Route = { type: "pod", namespace: "a", name: "api" };
+    const b: Route = { type: "pod", namespace: "b", name: "api" };
+    expect(routeKey(a)).not.toBe(routeKey(b));
+  });
+
+  it("separates the same name in two kinds", () => {
+    const a: Route = {
+      type: "object",
+      resource: { group: "", version: "v1", kind: "Service" },
+      namespace: "default",
+      name: "api",
+    };
+    const b: Route = {
+      type: "object",
+      resource: { group: "apps", version: "v1", kind: "Deployment" },
+      namespace: "default",
+      name: "api",
+    };
+    expect(routeKey(a)).not.toBe(routeKey(b));
+  });
+
+  it("separates a listing from a cluster-scoped object of the same name", () => {
+    expect(routeKey({ type: "nodes" })).not.toBe(
+      routeKey({ type: "node", name: "nodes" }),
+    );
+  });
+});
+
+describe("routeLabel", () => {
+  it("names a listing", () => {
+    expect(routeLabel({ type: "pods" })).toBe("Pods");
+    expect(routeLabel({ type: "kind", entry })).toBe("Deployments");
+  });
+
+  it("names an object by name alone, because a tab is narrow", () => {
+    expect(routeLabel({ type: "pod", namespace: "kube-system", name: "coredns" })).toBe(
+      "coredns",
+    );
+  });
+});
+
+describe("routeTitle", () => {
+  it("qualifies a namespaced object", () => {
+    expect(routeTitle({ type: "pod", namespace: "kube-system", name: "coredns" })).toBe(
+      "kube-system/coredns",
+    );
+  });
+
+  it("leaves a cluster-scoped object unqualified", () => {
+    expect(
+      routeTitle({
+        type: "object",
+        resource: { group: "", version: "v1", kind: "PersistentVolume" },
+        namespace: null,
+        name: "pv-1",
+      }),
+    ).toBe("PersistentVolume pv-1");
+  });
+});
+
+describe("isDetail", () => {
+  it("is true for one object and false for a listing", () => {
+    expect(isDetail({ type: "pod", namespace: "a", name: "b" })).toBe(true);
+    expect(isDetail({ type: "kind", entry })).toBe(false);
+  });
+});
+
+describe("parentOf", () => {
+  it("gives a detail route its listing", () => {
+    expect(parentOf({ type: "pod", namespace: "a", name: "b" })).toEqual({
+      type: "pods",
+    });
+    expect(parentOf({ type: "node", name: "n" })).toEqual({ type: "nodes" });
+  });
+
+  it("gives a listing nothing to sit under", () => {
+    expect(parentOf({ type: "pods" })).toBeNull();
+  });
+});

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,0 +1,152 @@
+import type { GvkRef } from "./api";
+import type { KindEntry } from "./kinds";
+
+// What the main area can be showing.
+//
+// Every destination in the app is one of these, whether it arrived from
+// the rail, from a row in a listing, or from following a related object.
+// Making that one closed set is what lets navigation be held centrally:
+// a history is a list of routes, and a tab is a history.
+//
+// Before this, each page held its own `selected` state, so opening an
+// object replaced the listing with no way back and no way to hold two
+// objects at once. The pages are now listings and detail views that
+// report where they want to go; where that lands is decided here.
+
+export type Route =
+  | { type: "nodes" }
+  | { type: "namespaces" }
+  | { type: "pods" }
+  | { type: "crds" }
+  | { type: "helm" }
+  | { type: "kind"; entry: KindEntry }
+  | { type: "node"; name: string }
+  | { type: "namespace"; name: string }
+  | { type: "pod"; namespace: string; name: string }
+  | { type: "release"; namespace: string; name: string }
+  | {
+      type: "object";
+      resource: GvkRef;
+      namespace: string | null;
+      name: string;
+    };
+
+/// The route the app opens on, and what a new tab starts at when there
+/// is nothing better to copy.
+export const HOME: Route = { type: "nodes" };
+
+/// How something was opened. Holding ⌘ or Ctrl asks for a tab of its
+/// own, the way it does on a link, so a list can be fanned out into
+/// several tabs without going back to it between each one.
+export type OpenIntent = "here" | "newTab";
+
+export function intentOf(e: {
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+}): OpenIntent {
+  return e.metaKey || e.ctrlKey ? "newTab" : "here";
+}
+
+/// Identity. Two routes with the same key are the same destination, so
+/// navigating to one you are already on is a no-op rather than a
+/// duplicate history entry, and a row you have already opened can be
+/// found in an existing tab instead of opening a second one.
+export function routeKey(route: Route): string {
+  switch (route.type) {
+    case "kind":
+      return `kind:${route.entry.id}`;
+    case "node":
+      return `node:${route.name}`;
+    case "namespace":
+      return `namespace:${route.name}`;
+    case "pod":
+      return `pod:${route.namespace}/${route.name}`;
+    case "release":
+      return `release:${route.namespace}/${route.name}`;
+    case "object": {
+      const { group, version, kind } = route.resource;
+      return `object:${group}/${version}/${kind}/${route.namespace ?? ""}/${route.name}`;
+    }
+    default:
+      return route.type;
+  }
+}
+
+/// How a route reads in a tab and in the breadcrumb.
+///
+/// Objects are labelled by name alone rather than by kind/name: the tab
+/// is narrow, and the name is the part that distinguishes one tab from
+/// its neighbour. The kind is carried by the breadcrumb's earlier
+/// crumbs and by the detail view's own header.
+export function routeLabel(route: Route): string {
+  switch (route.type) {
+    case "nodes":
+      return "Nodes";
+    case "namespaces":
+      return "Namespaces";
+    case "pods":
+      return "Pods";
+    case "crds":
+      return "CRDs";
+    case "helm":
+      return "Helm";
+    case "kind":
+      return route.entry.label;
+    case "node":
+    case "namespace":
+    case "pod":
+    case "release":
+    case "object":
+      return route.name;
+  }
+}
+
+/// A longer form for tooltips and for the breadcrumb, where there is
+/// room to say which namespace an object is in.
+export function routeTitle(route: Route): string {
+  switch (route.type) {
+    case "pod":
+    case "release":
+      return `${route.namespace}/${route.name}`;
+    case "object":
+      return route.namespace
+        ? `${route.resource.kind} ${route.namespace}/${route.name}`
+        : `${route.resource.kind} ${route.name}`;
+    case "node":
+      return `Node ${route.name}`;
+    case "namespace":
+      return `Namespace ${route.name}`;
+    default:
+      return routeLabel(route);
+  }
+}
+
+/// Whether a route shows one object rather than a listing. Detail views
+/// get the navigation chrome; listings are already the top of a trail.
+export function isDetail(route: Route): boolean {
+  return (
+    route.type === "node" ||
+    route.type === "namespace" ||
+    route.type === "pod" ||
+    route.type === "release" ||
+    route.type === "object"
+  );
+}
+
+/// The listing a detail route belongs under, so opening an object from
+/// the command palette still lands with a trail behind it rather than
+/// at the top of an empty history.
+export function parentOf(route: Route): Route | null {
+  switch (route.type) {
+    case "node":
+      return { type: "nodes" };
+    case "namespace":
+      return { type: "namespaces" };
+    case "pod":
+      return { type: "pods" };
+    case "release":
+      return { type: "helm" };
+    default:
+      return null;
+  }
+}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,5 +1,6 @@
 import type { GvkRef } from "./api";
 import { KIND_SECTIONS, type KindEntry } from "./kinds";
+import type { SortState } from "./sort";
 
 // What the main area can be showing.
 //
@@ -13,13 +14,30 @@ import { KIND_SECTIONS, type KindEntry } from "./kinds";
 // objects at once. The pages are now listings and detail views that
 // report where they want to go; where that lands is decided here.
 
+/// How a listing is presented: the namespace it is scoped to, the text
+/// narrowing it, how it is sorted, and whether the wide columns are out.
+///
+/// This rides on the route rather than in the page's own state because a
+/// page unmounts the moment you open something from it. Holding it here
+/// means the filter you set survives opening a pod and coming back, two
+/// tabs on the same kind can be scoped to different namespaces, and a
+/// route is a full description of what is on screen rather than half of
+/// one.
+export interface ListView {
+  /// Empty string means every namespace, matching `kubectl -A`.
+  namespace?: string;
+  query?: string;
+  sort?: SortState | null;
+  wide?: boolean;
+}
+
 export type Route =
-  | { type: "nodes" }
-  | { type: "namespaces" }
-  | { type: "pods" }
-  | { type: "crds" }
-  | { type: "helm" }
-  | { type: "kind"; entry: KindEntry }
+  | { type: "nodes"; view?: ListView }
+  | { type: "namespaces"; view?: ListView }
+  | { type: "pods"; view?: ListView }
+  | { type: "crds"; view?: ListView }
+  | { type: "helm"; view?: ListView }
+  | { type: "kind"; entry: KindEntry; view?: ListView }
   | { type: "node"; name: string }
   | { type: "namespace"; name: string }
   | { type: "pod"; namespace: string; name: string }
@@ -51,6 +69,11 @@ export function intentOf(e: {
 /// navigating to one you are already on is a no-op rather than a
 /// duplicate history entry, and a row you have already opened can be
 /// found in an existing tab instead of opening a second one.
+///
+/// Deliberately blind to `view`: a listing at a different namespace is
+/// the same destination presented differently, not somewhere new. That
+/// is what keeps a rail click on the listing you are already reading
+/// from throwing away the filter you set on it.
 export function routeKey(route: Route): string {
   switch (route.type) {
     case "kind":
@@ -131,6 +154,16 @@ export function isDetail(route: Route): boolean {
     route.type === "release" ||
     route.type === "object"
   );
+}
+
+/// The view a listing is currently showing, or an empty one.
+export function listViewOf(route: Route): ListView {
+  return "view" in route && route.view ? route.view : {};
+}
+
+/// The same route, presented differently.
+export function withListView(route: Route, patch: Partial<ListView>): Route {
+  return { ...route, view: { ...listViewOf(route), ...patch } } as Route;
 }
 
 /// The rail's own entry for a kind, so a breadcrumb says "DaemonSets"

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,5 +1,5 @@
 import type { GvkRef } from "./api";
-import type { KindEntry } from "./kinds";
+import { KIND_SECTIONS, type KindEntry } from "./kinds";
 
 // What the main area can be showing.
 //
@@ -131,6 +131,77 @@ export function isDetail(route: Route): boolean {
     route.type === "release" ||
     route.type === "object"
   );
+}
+
+/// The rail's own entry for a kind, so a breadcrumb says "DaemonSets"
+/// the way the rail does rather than "DaemonSet" the way the API does.
+/// Falls back to the bare kind for anything not in the rail, which is
+/// every custom resource.
+function kindEntryFor(gvk: GvkRef): KindEntry {
+  const id = `${gvk.group}/${gvk.version}/${gvk.kind}`;
+  for (const section of KIND_SECTIONS) {
+    const match = section.items.find((entry) => entry.id === id);
+    if (match) return match;
+  }
+  return { id, label: gvk.kind, gvk };
+}
+
+/// One step in the breadcrumb.
+export interface Crumb {
+  label: string;
+  /// The long form, for the tooltip.
+  title: string;
+  /// Where it goes, or null for the step you are already standing on.
+  route: Route | null;
+}
+
+/// The breadcrumb for a route.
+///
+/// This describes where an object sits, not how you came to be looking
+/// at it. Those are different questions and only one of them makes a
+/// breadcrumb: a trail of visited routes reads "Nodes › Pods › some-pod
+/// › Jobs › DaemonSets › some-daemonset", which is a record of wandering
+/// and implies a containment that does not exist. Where you have been is
+/// what the back and forward arrows are for.
+///
+/// So the crumbs are derived from the current route alone — its kind's
+/// listing, its namespace, and itself.
+export function crumbsFor(route: Route): Crumb[] {
+  const at = (r: Route, current: boolean): Crumb => ({
+    label: routeLabel(r),
+    title: routeTitle(r),
+    route: current ? null : r,
+  });
+  const here = at(route, true);
+  const namespaceOf = (name: string) => at({ type: "namespace", name }, false);
+
+  switch (route.type) {
+    case "node":
+      return [at({ type: "nodes" }, false), here];
+
+    case "namespace":
+      return [at({ type: "namespaces" }, false), here];
+
+    case "pod":
+      return [at({ type: "pods" }, false), namespaceOf(route.namespace), here];
+
+    case "release":
+      return [at({ type: "helm" }, false), namespaceOf(route.namespace), here];
+
+    case "object": {
+      const listing: Route = { type: "kind", entry: kindEntryFor(route.resource) };
+      // Cluster-scoped objects have no namespace to sit in, and an empty
+      // crumb between the kind and the name would only be noise.
+      return route.namespace
+        ? [at(listing, false), namespaceOf(route.namespace), here]
+        : [at(listing, false), here];
+    }
+
+    default:
+      // A listing is the top of its own hierarchy; there is nothing above
+      // Pods to put in front of it.
+      return [here];
+  }
 }
 
 /// The listing a detail route belongs under, so opening an object from

--- a/src/lib/sort.test.ts
+++ b/src/lib/sort.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareValues,
+  nextSort,
+  parseDuration,
+  parseRatio,
+  sortRows,
+  type SortValue,
+} from "./sort";
+
+/// Sorts a bare list of cell values the way a column would.
+function order(values: SortValue[], direction: "asc" | "desc" = "asc") {
+  return sortRows(values, (v) => v, direction);
+}
+
+describe("nextSort", () => {
+  it("starts ascending on a new column", () => {
+    expect(nextSort(null, "age")).toEqual({ key: "age", direction: "asc" });
+  });
+
+  it("cycles ascending, descending, then off", () => {
+    const asc = nextSort(null, "age");
+    const desc = nextSort(asc, "age");
+    expect(desc).toEqual({ key: "age", direction: "desc" });
+    // Off is a real state: the server's own order is what kubectl prints,
+    // and getting back to it should not need a reload.
+    expect(nextSort(desc, "age")).toBeNull();
+  });
+
+  it("starts over when a different column is clicked", () => {
+    const desc = { key: "age", direction: "desc" as const };
+    expect(nextSort(desc, "name")).toEqual({ key: "name", direction: "asc" });
+  });
+});
+
+describe("parseDuration", () => {
+  it("reads the ages the API server prints", () => {
+    expect(parseDuration("30s")).toBe(30);
+    expect(parseDuration("5m")).toBe(300);
+    expect(parseDuration("2h")).toBe(7200);
+    expect(parseDuration("3d")).toBe(259_200);
+  });
+
+  it("reads a compound age", () => {
+    expect(parseDuration("4h5m")).toBe(4 * 3600 + 5 * 60);
+    expect(parseDuration("2y64d")).toBe(2 * 31_536_000 + 64 * 86_400);
+  });
+
+  it("refuses anything that is not one", () => {
+    expect(parseDuration("Running")).toBeNull();
+    expect(parseDuration("1/1")).toBeNull();
+    expect(parseDuration("v1.33.1")).toBeNull();
+    expect(parseDuration("")).toBeNull();
+    // A bare number has no unit, so it is a count and not an age.
+    expect(parseDuration("12")).toBeNull();
+  });
+});
+
+describe("parseRatio", () => {
+  it("reads a ready count", () => {
+    expect(parseRatio("1/1")).toEqual({ ratio: 1, total: 1 });
+    expect(parseRatio("0/3")).toEqual({ ratio: 0, total: 3 });
+  });
+
+  it("treats nothing-to-be-ready as ready rather than as NaN", () => {
+    expect(parseRatio("0/0")).toEqual({ ratio: 1, total: 0 });
+  });
+
+  it("refuses anything that is not one", () => {
+    expect(parseRatio("kube-system")).toBeNull();
+    expect(parseRatio("1")).toBeNull();
+  });
+});
+
+describe("sorting ages", () => {
+  it("orders by elapsed time rather than alphabetically", () => {
+    // The whole reason this file exists: as text, "10m" sorts before
+    // "2d", and "65d" before "9h".
+    expect(order(["65d", "10m", "2d", "9h", "30s"])).toEqual([
+      "30s",
+      "10m",
+      "9h",
+      "2d",
+      "65d",
+    ]);
+  });
+
+  it("reverses cleanly", () => {
+    expect(order(["10m", "65d", "9h"], "desc")).toEqual(["65d", "9h", "10m"]);
+  });
+});
+
+describe("sorting ready counts", () => {
+  it("puts the least ready first", () => {
+    // What the column is scanned for.
+    expect(order(["1/1", "0/1", "2/3", "3/3"])).toEqual([
+      "0/1",
+      "2/3",
+      "1/1",
+      "3/3",
+    ]);
+  });
+
+  it("breaks a tie on the larger set", () => {
+    expect(order(["1/1", "5/5"])).toEqual(["1/1", "5/5"]);
+  });
+});
+
+describe("sorting numbers", () => {
+  it("orders restart counts numerically, not as text", () => {
+    expect(order([0, 12, 2, 7])).toEqual([0, 2, 7, 12]);
+  });
+
+  it("orders numbers that arrive as strings", () => {
+    // Server-printed tables send every cell as a string.
+    expect(order(["0", "12", "2", "7"])).toEqual(["0", "2", "7", "12"]);
+  });
+});
+
+describe("sorting names", () => {
+  it("orders a generated name the way a person reads it", () => {
+    expect(order(["pod-10", "pod-2", "pod-1"])).toEqual([
+      "pod-1",
+      "pod-2",
+      "pod-10",
+    ]);
+  });
+
+  it("ignores case", () => {
+    expect(order(["beta", "Alpha"])).toEqual(["Alpha", "beta"]);
+  });
+});
+
+describe("missing values", () => {
+  it("sinks them, whichever way the sort runs", () => {
+    // A column of em dashes at the top is not what anyone wanted from a
+    // sort, so absence is not a value that can win.
+    expect(order(["3d", "—", "1h"])).toEqual(["1h", "3d", "—"]);
+    expect(order(["3d", "—", "1h"], "desc")).toEqual(["3d", "1h", "—"]);
+  });
+
+  it("treats the server's several ways of saying nothing alike", () => {
+    expect(order(["b", "<none>", "a", null, ""])).toEqual([
+      "a",
+      "b",
+      "<none>",
+      null,
+      "",
+    ]);
+  });
+});
+
+describe("sortRows", () => {
+  it("is stable, so equal rows keep the order the server sent", () => {
+    const rows = [
+      { name: "c", phase: "Running" },
+      { name: "a", phase: "Running" },
+      { name: "b", phase: "Pending" },
+    ];
+    expect(sortRows(rows, (r) => r.phase, "asc").map((r) => r.name)).toEqual([
+      "b",
+      "c",
+      "a",
+    ]);
+  });
+
+  it("leaves the input alone", () => {
+    const rows = ["b", "a"];
+    sortRows(rows, (r) => r, "asc");
+    expect(rows).toEqual(["b", "a"]);
+  });
+});
+
+describe("compareValues", () => {
+  it("is consistent in both directions", () => {
+    expect(compareValues("1h", "3d")).toBeLessThan(0);
+    expect(compareValues("3d", "1h")).toBeGreaterThan(0);
+    expect(compareValues("3d", "3d")).toBe(0);
+  });
+});

--- a/src/lib/sort.ts
+++ b/src/lib/sort.ts
@@ -1,0 +1,136 @@
+// Sorting a listing, in the units the listing is actually in.
+//
+// A string sort is wrong for almost every column a Kubernetes table has.
+// "10m" sorts before "2d" and "65d" before "9h"; "1/1" and "0/3" compare
+// as text; "pod-10" lands before "pod-2". A sort that is quietly wrong is
+// worse than no sort at all, because the answer looks ordered — so the
+// comparator understands what it is looking at rather than falling back
+// to lexical order and hoping.
+//
+// Everything here is pure, and works on values the columns hand over
+// rather than on the rendered cell: a cell is a React node, and sorting
+// by markup would sort by whatever the renderer happened to emit.
+
+export type SortDirection = "asc" | "desc";
+
+export interface SortState {
+  /// The `key` of the column being sorted on.
+  key: string;
+  direction: SortDirection;
+}
+
+/// What a column can be sorted by.
+export type SortValue = string | number | null | undefined;
+
+/// Clicking a header cycles ascending, descending, then off.
+///
+/// Off is a real state rather than a third click that does nothing: the
+/// server's own order is meaningful — it is what `kubectl get` prints —
+/// so getting back to it should not require reloading the view.
+export function nextSort(current: SortState | null, key: string): SortState | null {
+  if (current?.key !== key) return { key, direction: "asc" };
+  if (current.direction === "asc") return { key, direction: "desc" };
+  return null;
+}
+
+const UNIT_SECONDS: Record<string, number> = {
+  s: 1,
+  m: 60,
+  h: 3600,
+  d: 86400,
+  y: 31_536_000,
+};
+
+/// Seconds in a Kubernetes age, or null if this is not one.
+///
+/// Matches what the API server prints: a run of number-unit pairs, most
+/// significant first — "65d", "4h5m", "2y64d", "1m2s".
+export function parseDuration(text: string): number | null {
+  const trimmed = text.trim();
+  if (!trimmed || !/^(\d+[smhdy])+$/.test(trimmed)) return null;
+
+  let seconds = 0;
+  for (const [, amount, unit] of trimmed.matchAll(/(\d+)([smhdy])/g)) {
+    seconds += Number(amount) * UNIT_SECONDS[unit];
+  }
+  return seconds;
+}
+
+/// A ready count — "1/1", "0/3" — as the fraction ready and the total.
+export function parseRatio(text: string): { ratio: number; total: number } | null {
+  const match = /^(\d+)\/(\d+)$/.exec(text.trim());
+  if (!match) return null;
+  const ready = Number(match[1]);
+  const total = Number(match[2]);
+  // Nothing to be ready counts as fully ready, rather than as NaN.
+  return { ratio: total === 0 ? 1 : ready / total, total };
+}
+
+/// Values that mean "the server did not say". They sort to the bottom
+/// whichever direction is asked for — a column of em dashes at the top
+/// is not what anyone wanted from a sort.
+const ABSENT = new Set(["", "—", "-", "<none>", "<unset>", "n/a"]);
+
+function isAbsent(value: SortValue): boolean {
+  if (value == null) return true;
+  return typeof value === "string" && ABSENT.has(value.trim().toLowerCase());
+}
+
+/// Order two cell values, understanding numbers, ages and ready counts
+/// before falling back to a natural string comparison.
+export function compareValues(a: SortValue, b: SortValue): number {
+  if (typeof a === "number" && typeof b === "number") return a - b;
+
+  const left = String(a);
+  const right = String(b);
+
+  const leftAge = parseDuration(left);
+  const rightAge = parseDuration(right);
+  if (leftAge !== null && rightAge !== null) return leftAge - rightAge;
+
+  const leftRatio = parseRatio(left);
+  const rightRatio = parseRatio(right);
+  if (leftRatio && rightRatio) {
+    return leftRatio.ratio - rightRatio.ratio || leftRatio.total - rightRatio.total;
+  }
+
+  const leftNumber = Number(left);
+  const rightNumber = Number(right);
+  if (left !== "" && right !== "" && !isNaN(leftNumber) && !isNaN(rightNumber)) {
+    return leftNumber - rightNumber;
+  }
+
+  // `numeric` so pod-2 comes before pod-10, which is the whole reason a
+  // generated name is readable at all.
+  return left.localeCompare(right, undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+}
+
+/// A copy of `rows` in the order asked for.
+///
+/// Stable, so rows the comparator considers equal keep the order the
+/// server sent them in — sorting by status should not shuffle the pods
+/// within each status on every render.
+export function sortRows<T>(
+  rows: T[],
+  sortValue: (row: T) => SortValue,
+  direction: SortDirection,
+): T[] {
+  const sign = direction === "asc" ? 1 : -1;
+
+  return rows
+    .map((row, index) => ({ row, index, value: sortValue(row) }))
+    .sort((a, b) => {
+      // Absent values sink regardless of direction, so reversing the
+      // sort does not fill the top of the table with nothing.
+      const aAbsent = isAbsent(a.value);
+      const bAbsent = isAbsent(b.value);
+      if (aAbsent !== bAbsent) return aAbsent ? 1 : -1;
+      if (aAbsent && bAbsent) return a.index - b.index;
+
+      return compareValues(a.value, b.value) * sign || a.index - b.index;
+    })
+    .map((entry) => entry.row);
+}

--- a/src/lib/workspace.test.ts
+++ b/src/lib/workspace.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import type { Route } from "./routes";
+import {
+  activeTab,
+  canGoBack,
+  canGoForward,
+  closeActiveTab,
+  closeTab,
+  currentRoute,
+  goBack,
+  goForward,
+  goTo,
+  navigate,
+  newWorkspace,
+  openInNewTab,
+  selectIndex,
+  selectTab,
+  trail,
+} from "./workspace";
+
+const pods: Route = { type: "pods" };
+const nodes: Route = { type: "nodes" };
+const helm: Route = { type: "helm" };
+
+function pod(name: string): Route {
+  return { type: "pod", namespace: "default", name };
+}
+
+function labels(ws: ReturnType<typeof newWorkspace>) {
+  return trail(activeTab(ws)).map((r) => (r.type === "pod" ? r.name : r.type));
+}
+
+describe("newWorkspace", () => {
+  it("starts with one tab on the home route", () => {
+    const ws = newWorkspace();
+    expect(ws.tabs).toHaveLength(1);
+    expect(currentRoute(ws)).toEqual(nodes);
+  });
+});
+
+describe("navigate", () => {
+  it("pushes onto the active tab's history", () => {
+    let ws = newWorkspace();
+    ws = navigate(ws, pods);
+    ws = navigate(ws, pod("api-1"));
+    expect(labels(ws)).toEqual(["nodes", "pods", "api-1"]);
+    expect(currentRoute(ws)).toEqual(pod("api-1"));
+  });
+
+  it("ignores a navigation to the route already on screen", () => {
+    let ws = newWorkspace();
+    ws = navigate(ws, pods);
+    const before = ws;
+    ws = navigate(ws, { type: "pods" });
+    expect(ws).toBe(before);
+  });
+
+  it("drops forward history when navigating after going back", () => {
+    let ws = newWorkspace();
+    ws = navigate(ws, pods);
+    ws = navigate(ws, pod("api-1"));
+    ws = goBack(ws);
+    ws = navigate(ws, helm);
+    expect(labels(ws)).toEqual(["nodes", "pods", "helm"]);
+    expect(canGoForward(activeTab(ws))).toBe(false);
+  });
+
+  it("leaves other tabs alone", () => {
+    let ws = newWorkspace();
+    ws = openInNewTab(ws, pods);
+    ws = navigate(ws, helm);
+    expect(ws.tabs[0].history).toEqual([nodes]);
+  });
+});
+
+describe("back and forward", () => {
+  it("moves the cursor without losing either side", () => {
+    let ws = newWorkspace();
+    ws = navigate(ws, pods);
+    ws = navigate(ws, pod("api-1"));
+
+    ws = goBack(ws);
+    expect(currentRoute(ws)).toEqual(pods);
+    expect(canGoBack(activeTab(ws))).toBe(true);
+    expect(canGoForward(activeTab(ws))).toBe(true);
+
+    ws = goForward(ws);
+    expect(currentRoute(ws)).toEqual(pod("api-1"));
+    expect(activeTab(ws).history).toHaveLength(3);
+  });
+
+  it("does nothing at either end", () => {
+    const ws = newWorkspace();
+    expect(goBack(ws)).toBe(ws);
+    expect(goForward(ws)).toBe(ws);
+  });
+});
+
+describe("goTo", () => {
+  it("jumps to a position in the trail and keeps what is ahead", () => {
+    let ws = newWorkspace();
+    ws = navigate(ws, pods);
+    ws = navigate(ws, pod("api-1"));
+    ws = goTo(ws, 0);
+    expect(currentRoute(ws)).toEqual(nodes);
+    expect(canGoForward(activeTab(ws))).toBe(true);
+  });
+
+  it("ignores an index outside the history", () => {
+    const ws = newWorkspace();
+    expect(goTo(ws, 4)).toBe(ws);
+    expect(goTo(ws, -1)).toBe(ws);
+  });
+});
+
+describe("openInNewTab", () => {
+  it("adds a tab and makes it active", () => {
+    let ws = newWorkspace();
+    ws = openInNewTab(ws, pods);
+    expect(ws.tabs).toHaveLength(2);
+    expect(ws.active).toBe(ws.tabs[1].id);
+    expect(currentRoute(ws)).toEqual(pods);
+  });
+
+  it("seeds a trail so the new tab can go back", () => {
+    let ws = newWorkspace();
+    ws = openInNewTab(ws, pod("api-1"), pods);
+    expect(canGoBack(activeTab(ws))).toBe(true);
+    expect(labels(ws)).toEqual(["pods", "api-1"]);
+  });
+
+  it("gives every tab a distinct id", () => {
+    let ws = newWorkspace();
+    ws = openInNewTab(ws, pods);
+    ws = openInNewTab(ws, helm);
+    expect(new Set(ws.tabs.map((t) => t.id)).size).toBe(3);
+  });
+});
+
+describe("selectTab", () => {
+  it("shows the named tab", () => {
+    let ws = newWorkspace();
+    const first = ws.tabs[0].id;
+    ws = openInNewTab(ws, pods);
+    ws = selectTab(ws, first);
+    expect(currentRoute(ws)).toEqual(nodes);
+  });
+
+  it("ignores a tab that is not open", () => {
+    const ws = newWorkspace();
+    expect(selectTab(ws, "gone")).toBe(ws);
+  });
+
+  it("selects by position, and ignores one past the end", () => {
+    let ws = newWorkspace();
+    ws = openInNewTab(ws, pods);
+    expect(currentRoute(selectIndex(ws, 0))).toEqual(nodes);
+    expect(selectIndex(ws, 9)).toBe(ws);
+  });
+});
+
+describe("closeTab", () => {
+  it("hands focus to the right-hand neighbour", () => {
+    let ws = newWorkspace();
+    ws = openInNewTab(ws, pods);
+    ws = openInNewTab(ws, helm);
+    ws = selectTab(ws, ws.tabs[1].id);
+    ws = closeActiveTab(ws);
+    expect(ws.tabs).toHaveLength(2);
+    expect(currentRoute(ws)).toEqual(helm);
+  });
+
+  it("falls back to the left when the last tab is closed", () => {
+    let ws = newWorkspace();
+    ws = openInNewTab(ws, pods);
+    ws = closeActiveTab(ws);
+    expect(currentRoute(ws)).toEqual(nodes);
+  });
+
+  it("keeps the active tab when a different one is closed", () => {
+    let ws = newWorkspace();
+    const first = ws.tabs[0].id;
+    ws = openInNewTab(ws, pods);
+    ws = closeTab(ws, first);
+    expect(ws.tabs).toHaveLength(1);
+    expect(currentRoute(ws)).toEqual(pods);
+  });
+
+  it("resets rather than empties the last tab", () => {
+    let ws = newWorkspace();
+    ws = navigate(ws, helm);
+    ws = closeActiveTab(ws);
+    expect(ws.tabs).toHaveLength(1);
+    expect(currentRoute(ws)).toEqual(nodes);
+    expect(canGoBack(activeTab(ws))).toBe(false);
+  });
+
+  it("ignores a tab that is not open", () => {
+    let ws = newWorkspace();
+    ws = openInNewTab(ws, pods);
+    expect(closeTab(ws, "gone")).toBe(ws);
+  });
+});

--- a/src/lib/workspace.test.ts
+++ b/src/lib/workspace.test.ts
@@ -9,13 +9,11 @@ import {
   currentRoute,
   goBack,
   goForward,
-  goTo,
   navigate,
   newWorkspace,
   openInNewTab,
   selectIndex,
   selectTab,
-  trail,
 } from "./workspace";
 
 const pods: Route = { type: "pods" };
@@ -27,7 +25,10 @@ function pod(name: string): Route {
 }
 
 function labels(ws: ReturnType<typeof newWorkspace>) {
-  return trail(activeTab(ws)).map((r) => (r.type === "pod" ? r.name : r.type));
+  const tab = activeTab(ws);
+  return tab.history
+    .slice(0, tab.index + 1)
+    .map((r) => (r.type === "pod" ? r.name : r.type));
 }
 
 describe("newWorkspace", () => {
@@ -93,23 +94,6 @@ describe("back and forward", () => {
     const ws = newWorkspace();
     expect(goBack(ws)).toBe(ws);
     expect(goForward(ws)).toBe(ws);
-  });
-});
-
-describe("goTo", () => {
-  it("jumps to a position in the trail and keeps what is ahead", () => {
-    let ws = newWorkspace();
-    ws = navigate(ws, pods);
-    ws = navigate(ws, pod("api-1"));
-    ws = goTo(ws, 0);
-    expect(currentRoute(ws)).toEqual(nodes);
-    expect(canGoForward(activeTab(ws))).toBe(true);
-  });
-
-  it("ignores an index outside the history", () => {
-    const ws = newWorkspace();
-    expect(goTo(ws, 4)).toBe(ws);
-    expect(goTo(ws, -1)).toBe(ws);
   });
 });
 

--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -63,11 +63,6 @@ export function canGoForward(tab: Tab): boolean {
   return tab.index < tab.history.length - 1;
 }
 
-/// The trail behind the tab, oldest first, ending at what is on screen.
-export function trail(tab: Tab): Route[] {
-  return tab.history.slice(0, tab.index + 1);
-}
-
 function replaceTab(ws: Workspace, id: string, next: Tab): Workspace {
   return { ...ws, tabs: ws.tabs.map((t) => (t.id === id ? next : t)) };
 }
@@ -158,11 +153,3 @@ export function goForward(ws: Workspace): Workspace {
   return replaceTab(ws, tab.id, { ...tab, index: tab.index + 1 });
 }
 
-/// Jump to a position in the active tab's trail — what clicking a
-/// breadcrumb does. Forward history is kept, so a crumb click is a
-/// several-step back rather than a new navigation.
-export function goTo(ws: Workspace, index: number): Workspace {
-  const tab = activeTab(ws);
-  if (index < 0 || index >= tab.history.length) return ws;
-  return replaceTab(ws, tab.id, { ...tab, index });
-}

--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -1,0 +1,168 @@
+import { HOME, routeKey, type Route } from "./routes";
+
+// Tabs, and the history behind each one.
+//
+// A tab is a history and a position in it, exactly like a browser's:
+// navigating pushes and truncates whatever was ahead, back and forward
+// move the cursor without losing either side. That is what makes
+// following a chain — pod, its ReplicaSet, the Deployment above it, the
+// Service that selects it — recoverable rather than a one-way trip.
+//
+// Everything here is a pure function over the workspace, so the whole
+// navigation model is testable without rendering anything. `App` holds
+// one of these in state and does nothing to it that is not in this file.
+
+export interface Tab {
+  id: string;
+  /// Oldest first. Never empty.
+  history: Route[];
+  /// Index into `history` of what the tab is showing.
+  index: number;
+}
+
+export interface Workspace {
+  tabs: Tab[];
+  /// Id of the tab on screen. Always names a tab in `tabs`.
+  active: string;
+  /// Source of tab ids. Held in the workspace rather than in a module
+  /// counter so the same sequence of calls always produces the same
+  /// workspace, which is what makes this testable.
+  nextId: number;
+}
+
+/// How many history entries a tab keeps. Long enough that no real
+/// session reaches it, bounded so a long-lived window cannot grow
+/// without limit.
+const HISTORY_LIMIT = 50;
+
+export function newWorkspace(route: Route = HOME): Workspace {
+  return {
+    tabs: [{ id: "t1", history: [route], index: 0 }],
+    active: "t1",
+    nextId: 2,
+  };
+}
+
+export function activeTab(ws: Workspace): Tab {
+  // The invariant that `active` names a tab is maintained by every
+  // function here; the fallback is so a corrupted workspace renders
+  // something rather than throwing in a render.
+  return ws.tabs.find((t) => t.id === ws.active) ?? ws.tabs[0];
+}
+
+export function currentRoute(ws: Workspace): Route {
+  const tab = activeTab(ws);
+  return tab.history[tab.index];
+}
+
+export function canGoBack(tab: Tab): boolean {
+  return tab.index > 0;
+}
+
+export function canGoForward(tab: Tab): boolean {
+  return tab.index < tab.history.length - 1;
+}
+
+/// The trail behind the tab, oldest first, ending at what is on screen.
+export function trail(tab: Tab): Route[] {
+  return tab.history.slice(0, tab.index + 1);
+}
+
+function replaceTab(ws: Workspace, id: string, next: Tab): Workspace {
+  return { ...ws, tabs: ws.tabs.map((t) => (t.id === id ? next : t)) };
+}
+
+/// Go to a route in the active tab, pushing it onto the history.
+///
+/// Navigating to what is already on screen does nothing, so clicking
+/// the rail entry you are already on does not fill the history with
+/// repeats of one listing.
+export function navigate(ws: Workspace, route: Route): Workspace {
+  const tab = activeTab(ws);
+  if (routeKey(tab.history[tab.index]) === routeKey(route)) return ws;
+
+  // Anything ahead of the cursor is dropped: having gone back and then
+  // somewhere new, the branch you left is no longer reachable forward.
+  const history = [...tab.history.slice(0, tab.index + 1), route];
+  const trimmed = history.slice(-HISTORY_LIMIT);
+  return replaceTab(ws, tab.id, {
+    ...tab,
+    history: trimmed,
+    index: trimmed.length - 1,
+  });
+}
+
+/// Open a route in a tab of its own and make it active.
+///
+/// `under` seeds the history so the new tab has a trail — opening a pod
+/// from the palette lands with Pods behind it, and back means something
+/// immediately rather than being dead on arrival.
+export function openInNewTab(
+  ws: Workspace,
+  route: Route,
+  under: Route | null = null,
+): Workspace {
+  const id = `t${ws.nextId}`;
+  const history = under ? [under, route] : [route];
+  const tab: Tab = { id, history, index: history.length - 1 };
+  return { ...ws, tabs: [...ws.tabs, tab], active: id, nextId: ws.nextId + 1 };
+}
+
+/// Show an existing tab.
+export function selectTab(ws: Workspace, id: string): Workspace {
+  return ws.tabs.some((t) => t.id === id) ? { ...ws, active: id } : ws;
+}
+
+export function selectIndex(ws: Workspace, i: number): Workspace {
+  const tab = ws.tabs[i];
+  return tab ? { ...ws, active: tab.id } : ws;
+}
+
+/// Close a tab.
+///
+/// The last tab is never closed — it is reset to the home route
+/// instead. A window with no tabs has nowhere to render and nothing to
+/// click, and every editor that allows it has to invent an empty state
+/// to fill the hole.
+export function closeTab(ws: Workspace, id: string): Workspace {
+  if (ws.tabs.length === 1) {
+    return ws.tabs[0].id === id ? newWorkspace() : ws;
+  }
+
+  const i = ws.tabs.findIndex((t) => t.id === id);
+  if (i < 0) return ws;
+
+  const tabs = ws.tabs.filter((t) => t.id !== id);
+  // Closing the active tab hands focus to its right-hand neighbour,
+  // falling back to the left when it was last — the behaviour every
+  // editor has, and the one that keeps a run of closes moving in one
+  // direction instead of jumping back to the start.
+  const active =
+    ws.active === id ? (tabs[i] ?? tabs[tabs.length - 1]).id : ws.active;
+  return { ...ws, tabs, active };
+}
+
+export function closeActiveTab(ws: Workspace): Workspace {
+  return closeTab(ws, ws.active);
+}
+
+export function goBack(ws: Workspace): Workspace {
+  const tab = activeTab(ws);
+  if (!canGoBack(tab)) return ws;
+  return replaceTab(ws, tab.id, { ...tab, index: tab.index - 1 });
+}
+
+export function goForward(ws: Workspace): Workspace {
+  const tab = activeTab(ws);
+  if (!canGoForward(tab)) return ws;
+  return replaceTab(ws, tab.id, { ...tab, index: tab.index + 1 });
+}
+
+/// Jump to a position in the active tab's trail — what clicking a
+/// breadcrumb does. Forward history is kept, so a crumb click is a
+/// several-step back rather than a new navigation.
+export function goTo(ws: Workspace, index: number): Workspace {
+  const tab = activeTab(ws);
+  if (index < 0 || index >= tab.history.length) return ws;
+  return replaceTab(ws, tab.id, { ...tab, index });
+}

--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -87,6 +87,20 @@ export function navigate(ws: Workspace, route: Route): Workspace {
   });
 }
 
+/// Swap what the active tab is showing, without adding to its history.
+///
+/// For a change to how a listing is presented — the namespace it is
+/// scoped to, the text filtering it, the column it is sorted by — rather
+/// than a move somewhere new. Pushing those would fill the history with
+/// one listing at every filter it has ever had, and make back mean "undo
+/// my last keystroke".
+export function replace(ws: Workspace, route: Route): Workspace {
+  const tab = activeTab(ws);
+  const history = [...tab.history];
+  history[tab.index] = route;
+  return replaceTab(ws, tab.id, { ...tab, history });
+}
+
 /// Open a route in a tab of its own and make it active.
 ///
 /// `under` seeds the history so the new tab has a trail — opening a pod

--- a/src/lib/zoom.test.ts
+++ b/src/lib/zoom.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyZoom,
+  canZoomIn,
+  canZoomOut,
+  clampZoom,
+  DEFAULT_ZOOM,
+  ZOOM_STEPS,
+  zoomIn,
+  zoomLabel,
+  zoomOut,
+} from "./zoom";
+
+describe("clampZoom", () => {
+  it("keeps a level that is already a step", () => {
+    for (const step of ZOOM_STEPS) expect(clampZoom(step)).toBe(step);
+  });
+
+  it("snaps to the nearest step", () => {
+    expect(clampZoom(1.2)).toBe(1.25);
+    expect(clampZoom(0.95)).toBe(0.9);
+  });
+
+  it("holds the ends", () => {
+    expect(clampZoom(9)).toBe(2);
+    expect(clampZoom(0.1)).toBe(0.75);
+  });
+
+  it("falls back to 100% for anything unreadable", () => {
+    // A settings file edited by hand, or written by a build that stored
+    // something else here. Rendering the app at four times its size is
+    // not the right answer to a value that cannot be parsed.
+    expect(clampZoom(NaN)).toBe(DEFAULT_ZOOM);
+    expect(clampZoom(undefined)).toBe(DEFAULT_ZOOM);
+    expect(clampZoom("big")).toBe(DEFAULT_ZOOM);
+    expect(clampZoom(0)).toBe(DEFAULT_ZOOM);
+    expect(clampZoom(-2)).toBe(DEFAULT_ZOOM);
+  });
+});
+
+describe("stepping", () => {
+  it("moves one step at a time", () => {
+    expect(zoomIn(1)).toBe(1.1);
+    expect(zoomOut(1)).toBe(0.9);
+  });
+
+  it("stops at the ends rather than running off", () => {
+    // So a held key does nothing surprising once it arrives.
+    expect(zoomIn(2)).toBe(2);
+    expect(zoomOut(0.75)).toBe(0.75);
+  });
+
+  it("steps from a level that is not on a step", () => {
+    expect(zoomIn(1.2)).toBe(1.5);
+    expect(zoomOut(1.2)).toBe(1.1);
+  });
+
+  it("says when it has run out", () => {
+    expect(canZoomIn(2)).toBe(false);
+    expect(canZoomIn(1)).toBe(true);
+    expect(canZoomOut(0.75)).toBe(false);
+    expect(canZoomOut(1)).toBe(true);
+  });
+
+  it("walks the whole range in both directions", () => {
+    let level: number = ZOOM_STEPS[0];
+    for (let i = 0; i < 20; i++) level = zoomIn(level);
+    expect(level).toBe(2);
+    for (let i = 0; i < 20; i++) level = zoomOut(level);
+    expect(level).toBe(0.75);
+  });
+});
+
+describe("zoomLabel", () => {
+  it("reads as a percentage", () => {
+    expect(zoomLabel(1)).toBe("100%");
+    expect(zoomLabel(1.25)).toBe("125%");
+    expect(zoomLabel(0.75)).toBe("75%");
+  });
+});
+
+describe("applyZoom", () => {
+  it("scales the root", () => {
+    applyZoom(1.5);
+    expect(document.documentElement.style.zoom).toBe("1.5");
+  });
+
+  it("leaves no trace at the default", () => {
+    applyZoom(1.5);
+    applyZoom(1);
+    expect(document.documentElement.style.zoom).toBe("");
+  });
+
+  it("refuses to paint something unreadable", () => {
+    applyZoom(1);
+    applyZoom(NaN);
+    expect(document.documentElement.style.zoom).toBe("");
+  });
+});

--- a/src/lib/zoom.ts
+++ b/src/lib/zoom.ts
@@ -1,0 +1,87 @@
+// Interface zoom.
+//
+// An accessibility control, not a convenience: 13px is the size this app
+// is drawn at, and for a good number of people that is simply too small
+// to read for an hour at a time. The alternative is the OS-wide display
+// scale, which means resizing every other window to fix one.
+//
+// Implemented as CSS `zoom` on the root element rather than by scaling
+// the root font size. Font scaling only reaches what is expressed in
+// rem, which leaves out exactly the panes worth enlarging — the log
+// viewer and the terminal draw at a fixed pixel size, and xterm measures
+// its own glyphs. `zoom` scales the layout itself, so everything goes
+// together and nothing has to opt in.
+
+/// The steps the app moves through, rather than a free-running
+/// percentage: every stop is a size the layout has been looked at in,
+/// and a stepped control is one you can hold a key on without landing
+/// somewhere absurd.
+export const ZOOM_STEPS = [0.75, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2] as const;
+
+export const DEFAULT_ZOOM = 1;
+
+/// The event the native menu emits, and what it can carry. A contract
+/// with `src-tauri/src/menu.rs`, so both ends name the same strings.
+export const ZOOM_EVENT = "menu:zoom";
+export const ZOOM_IN = "zoom-in";
+export const ZOOM_OUT = "zoom-out";
+export const ZOOM_RESET = "zoom-reset";
+
+const MIN = ZOOM_STEPS[0];
+const MAX = ZOOM_STEPS[ZOOM_STEPS.length - 1];
+
+/// The nearest step to a level, for a settings file that has been edited
+/// by hand or written by an older build. Anything unreadable comes back
+/// as 100%: a preference that cannot be parsed is not a reason to render
+/// the app at four times its size.
+export function clampZoom(level: unknown): number {
+  const value = typeof level === "number" ? level : Number(level);
+  if (!Number.isFinite(value) || value <= 0) return DEFAULT_ZOOM;
+  if (value <= MIN) return MIN;
+  if (value >= MAX) return MAX;
+
+  return ZOOM_STEPS.reduce((best, step) =>
+    Math.abs(step - value) < Math.abs(best - value) ? step : best,
+  );
+}
+
+function step(level: number, direction: 1 | -1): number {
+  const current = clampZoom(level);
+  const i = ZOOM_STEPS.indexOf(current as (typeof ZOOM_STEPS)[number]);
+  // At either end this returns the same level, so the caller can call it
+  // repeatedly without checking and nothing moves.
+  return ZOOM_STEPS[Math.min(ZOOM_STEPS.length - 1, Math.max(0, i + direction))];
+}
+
+export function zoomIn(level: number): number {
+  return step(level, 1);
+}
+
+export function zoomOut(level: number): number {
+  return step(level, -1);
+}
+
+export function canZoomIn(level: number): boolean {
+  return clampZoom(level) < MAX;
+}
+
+export function canZoomOut(level: number): boolean {
+  return clampZoom(level) > MIN;
+}
+
+/// How a level reads to a person.
+export function zoomLabel(level: number): string {
+  return `${Math.round(clampZoom(level) * 100)}%`;
+}
+
+/// Paint it. Removed rather than set to 1 at the default, so the ordinary
+/// case leaves no trace in the DOM and nothing to explain later.
+export function applyZoom(level: number): void {
+  const root = document.documentElement;
+  const value = clampZoom(level);
+  if (value === DEFAULT_ZOOM) {
+    root.style.removeProperty("zoom");
+  } else {
+    root.style.setProperty("zoom", String(value));
+  }
+}

--- a/src/pages/ContextPicker.test.tsx
+++ b/src/pages/ContextPicker.test.tsx
@@ -35,7 +35,13 @@ const setContextPinned = vi.mocked(api.setContextPinned);
 const connectedClusters = vi.mocked(api.connectedClusters);
 
 function settings(over: Partial<import("../lib/api").Settings> = {}) {
-  return { theme: "system" as const, recentContexts: [], pinnedContexts: [], ...over };
+  return {
+    theme: "system" as const,
+    recentContexts: [],
+    pinnedContexts: [],
+    zoom: 1,
+    ...over,
+  };
 }
 
 function context(name: string, overrides: Partial<ContextInfo> = {}): ContextInfo {

--- a/src/pages/Helm.test.tsx
+++ b/src/pages/Helm.test.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Helm } from "./Helm";
+import { Helm, ReleaseDetail as ReleaseDetailView } from "./Helm";
 import {
   api,
   type ReleaseDetail,
@@ -85,25 +85,34 @@ function detail(overrides: Partial<ReleaseDetail> = {}): ReleaseDetail {
   };
 }
 
+const onOpen = vi.fn();
+
+function client() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
 function renderHelm() {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
   render(
-    <QueryClientProvider client={client}>
-      <Helm />
+    <QueryClientProvider client={client()}>
+      <Helm onOpen={onOpen} />
     </QueryClientProvider>,
   );
   return userEvent.setup();
 }
 
-/// Opens the release detail from the list.
-async function openRelease(user: ReturnType<typeof userEvent.setup>) {
-  await user.click(await screen.findByText("prom"));
-  await waitFor(() => expect(getHelmRelease).toHaveBeenCalled());
+/// The detail view, rendered as the workspace renders it: on its own,
+/// for one release, rather than nested inside the listing.
+function renderRelease() {
+  render(
+    <QueryClientProvider client={client()}>
+      <ReleaseDetailView namespace="monitoring" name="prom" onClose={vi.fn()} />
+    </QueryClientProvider>,
+  );
+  return userEvent.setup();
 }
 
 beforeEach(() => {
+  onOpen.mockReset();
   listHelmReleases.mockReset().mockResolvedValue([summary()]);
   getHelmRelease.mockReset().mockResolvedValue(detail());
   listNamespaces
@@ -138,6 +147,17 @@ describe("Helm release list", () => {
     );
   });
 
+  it("reports the release it was told to open", async () => {
+    const user = renderHelm();
+    await user.click(await screen.findByText("prom"));
+    await waitFor(() =>
+      expect(onOpen).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "prom", namespace: "monitoring" }),
+        "here",
+      ),
+    );
+  });
+
   it("surfaces a failure to list", async () => {
     listHelmReleases.mockRejectedValue({
       kind: "kubernetes",
@@ -149,15 +169,15 @@ describe("Helm release list", () => {
 });
 
 describe("Helm release detail", () => {
-  it("opens the release that was clicked", async () => {
-    const user = renderHelm();
-    await openRelease(user);
+  it("reads the release it was pointed at", async () => {
+    renderRelease();
+    await waitFor(() => expect(getHelmRelease).toHaveBeenCalled());
     expect(getHelmRelease).toHaveBeenCalledWith("monitoring", "prom");
   });
 
   it("leads with the live revision", async () => {
-    const user = renderHelm();
-    await openRelease(user);
+    renderRelease();
+    await waitFor(() => expect(getHelmRelease).toHaveBeenCalled());
     expect(await screen.findByText("rev 3")).toBeInTheDocument();
     expect(screen.getByText("kube-prometheus-stack")).toBeInTheDocument();
     expect(screen.getByText("85.3.3")).toBeInTheDocument();
@@ -166,8 +186,8 @@ describe("Helm release detail", () => {
   it("shows what was overridden, not the chart's defaults", async () => {
     // `helm get values` makes the same distinction, and it is the one
     // that answers "what did we actually configure".
-    const user = renderHelm();
-    await openRelease(user);
+    const user = renderRelease();
+    await waitFor(() => expect(getHelmRelease).toHaveBeenCalled());
     await user.click(screen.getByRole("button", { name: "Values" }));
 
     expect(await screen.findByText(/grafana/)).toBeInTheDocument();
@@ -176,8 +196,8 @@ describe("Helm release detail", () => {
   it("says so when a release runs the chart's defaults", async () => {
     // An empty YAML pane would read as a failure to load.
     getHelmRelease.mockResolvedValue(detail({ values: "" }));
-    const user = renderHelm();
-    await openRelease(user);
+    const user = renderRelease();
+    await waitFor(() => expect(getHelmRelease).toHaveBeenCalled());
     await user.click(screen.getByRole("button", { name: "Values" }));
 
     expect(
@@ -188,8 +208,8 @@ describe("Helm release detail", () => {
   it("renders the notes as written", async () => {
     // Usually the only place a chart says how to reach what it just
     // installed, and the line breaks in it are meaningful.
-    const user = renderHelm();
-    await openRelease(user);
+    const user = renderRelease();
+    await waitFor(() => expect(getHelmRelease).toHaveBeenCalled());
     await user.click(screen.getByRole("button", { name: "Notes" }));
 
     expect(await screen.findByText(/localhost:3000/)).toBeInTheDocument();
@@ -197,8 +217,8 @@ describe("Helm release detail", () => {
 
   it("says so when a chart ships no notes", async () => {
     getHelmRelease.mockResolvedValue(detail({ notes: null }));
-    const user = renderHelm();
-    await openRelease(user);
+    const user = renderRelease();
+    await waitFor(() => expect(getHelmRelease).toHaveBeenCalled());
     await user.click(screen.getByRole("button", { name: "Notes" }));
 
     expect(await screen.findByText(/ships no notes/)).toBeInTheDocument();
@@ -206,8 +226,8 @@ describe("Helm release detail", () => {
 
   it("reads its history backwards in time", async () => {
     // The way `helm history` prints it: the current revision at the top.
-    const user = renderHelm();
-    await openRelease(user);
+    const user = renderRelease();
+    await waitFor(() => expect(getHelmRelease).toHaveBeenCalled());
     await user.click(screen.getByRole("button", { name: "History" }));
 
     expect(await screen.findByText("superseded")).toBeInTheDocument();
@@ -220,8 +240,8 @@ describe("Helm release detail", () => {
   });
 
   it("renders the manifest that was applied", async () => {
-    const user = renderHelm();
-    await openRelease(user);
+    const user = renderRelease();
+    await waitFor(() => expect(getHelmRelease).toHaveBeenCalled());
     await user.click(screen.getByRole("button", { name: "Manifest" }));
 
     expect(await screen.findByText(/Service/)).toBeInTheDocument();

--- a/src/pages/Helm.test.tsx
+++ b/src/pages/Helm.test.tsx
@@ -86,6 +86,7 @@ function detail(overrides: Partial<ReleaseDetail> = {}): ReleaseDetail {
 }
 
 const onOpen = vi.fn();
+const onView = vi.fn();
 
 function client() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -94,7 +95,7 @@ function client() {
 function renderHelm() {
   render(
     <QueryClientProvider client={client()}>
-      <Helm onOpen={onOpen} />
+      <Helm onOpen={onOpen} view={{}} onView={onView} />
     </QueryClientProvider>,
   );
   return userEvent.setup();
@@ -113,6 +114,7 @@ function renderRelease() {
 
 beforeEach(() => {
   onOpen.mockReset();
+  onView.mockReset();
   listHelmReleases.mockReset().mockResolvedValue([summary()]);
   getHelmRelease.mockReset().mockResolvedValue(detail());
   listNamespaces
@@ -137,11 +139,24 @@ describe("Helm release list", () => {
     expect(await screen.findByText(/secret driver/)).toBeInTheDocument();
   });
 
-  it("narrows to one namespace when picked", async () => {
+  it("reports the namespace it was asked to narrow to", async () => {
+    // The page reports; the workspace keeps it, so the filter survives
+    // opening a release and coming back.
     const user = renderHelm();
     await screen.findByText("prom");
 
     await user.selectOptions(screen.getByRole("combobox"), "monitoring");
+    await waitFor(() =>
+      expect(onView).toHaveBeenCalledWith({ namespace: "monitoring" }),
+    );
+  });
+
+  it("asks the cluster for the namespace the view names", async () => {
+    render(
+      <QueryClientProvider client={client()}>
+        <Helm onOpen={onOpen} view={{ namespace: "monitoring" }} onView={onView} />
+      </QueryClientProvider>,
+    );
     await waitFor(() =>
       expect(listHelmReleases).toHaveBeenCalledWith("monitoring"),
     );

--- a/src/pages/Helm.tsx
+++ b/src/pages/Helm.tsx
@@ -16,7 +16,7 @@ import {
   type ReleaseRevision,
   type ReleaseSummary,
 } from "../lib/api";
-import type { OpenIntent } from "../lib/routes";
+import type { ListView, OpenIntent } from "../lib/routes";
 
 // Helm releases, read out of the release Secrets rather than the CLI.
 //
@@ -182,10 +182,15 @@ export function ReleaseDetail({
 
 export function Helm({
   onOpen,
+  view,
+  onView,
 }: {
   onOpen: (release: ReleaseSummary, intent: OpenIntent) => void;
+  view: ListView;
+  onView: (patch: Partial<ListView>) => void;
 }) {
-  const [namespace, setNamespace] = useState("");
+  const namespace = view.namespace ?? "";
+  const setNamespace = (next: string) => onView({ namespace: next });
 
   const q = useQuery({
     queryKey: ["helm-releases", namespace],
@@ -238,8 +243,14 @@ export function Helm({
         searchText={(r) => `${r.name} ${r.namespace} ${r.chart} ${r.status}`}
         empty="No Helm releases. Loupe reads the default secret driver; a cluster configured for the configmap or SQL backend keeps them elsewhere."
         onRowClick={onOpen}
+        view={view}
+        onView={onView}
         toolbar={
-          <Select value={namespace} onChange={setNamespace}>
+          <Select
+            title="Namespace"
+            value={namespace}
+            onChange={setNamespace}
+          >
             <option value="">All namespaces</option>
             {(namespaces.data ?? []).map((ns) => (
               <option key={ns.name} value={ns.name}>

--- a/src/pages/Helm.tsx
+++ b/src/pages/Helm.tsx
@@ -16,6 +16,7 @@ import {
   type ReleaseRevision,
   type ReleaseSummary,
 } from "../lib/api";
+import type { OpenIntent } from "../lib/routes";
 
 // Helm releases, read out of the release Secrets rather than the CLI.
 //
@@ -51,7 +52,7 @@ const TABS: TabSpec[] = [
   { id: "history", label: "History" },
 ];
 
-function ReleaseDetail({
+export function ReleaseDetail({
   namespace,
   name,
   onClose,
@@ -104,7 +105,6 @@ function ReleaseDetail({
       tab={tab}
       onTab={setTab}
       onClose={onClose}
-      backTo="releases"
       error={q.error}
     >
       {!release && <OverviewSkeleton />}
@@ -180,9 +180,12 @@ function ReleaseDetail({
   );
 }
 
-export function Helm() {
+export function Helm({
+  onOpen,
+}: {
+  onOpen: (release: ReleaseSummary, intent: OpenIntent) => void;
+}) {
   const [namespace, setNamespace] = useState("");
-  const [selected, setSelected] = useState<ReleaseSummary | null>(null);
 
   const q = useQuery({
     queryKey: ["helm-releases", namespace],
@@ -219,16 +222,6 @@ export function Helm() {
     },
   ];
 
-  if (selected) {
-    return (
-      <ReleaseDetail
-        namespace={selected.namespace}
-        name={selected.name}
-        onClose={() => setSelected(null)}
-      />
-    );
-  }
-
   return (
     <Panel
       title="Helm releases"
@@ -244,7 +237,7 @@ export function Helm() {
         rowKey={(r) => `${r.namespace}/${r.name}`}
         searchText={(r) => `${r.name} ${r.namespace} ${r.chart} ${r.status}`}
         empty="No Helm releases. Loupe reads the default secret driver; a cluster configured for the configmap or SQL backend keeps them elsewhere."
-        onRowClick={setSelected}
+        onRowClick={onOpen}
         toolbar={
           <Select value={namespace} onChange={setNamespace}>
             <option value="">All namespaces</option>

--- a/src/pages/KindBrowser.test.tsx
+++ b/src/pages/KindBrowser.test.tsx
@@ -1,12 +1,16 @@
-// Cross-kind navigation is what the Related tab is for: from a
-// Deployment you reach its ReplicaSet, from there its Pods, and from a
-// Pod the ConfigMap it mounts. The listing stays where it was.
+// One kind's listing, with the columns the API server printed.
+//
+// Following an object out of here — into its ReplicaSet, its Deployment,
+// the ConfigMap it mounts — is the workspace's job now, and is covered
+// where that lives: the mechanics in lib/workspace.test.ts, and the
+// whole trip through the UI in App.test.tsx. What is left to cover here
+// is the table.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { KindBrowser } from "./KindBrowser";
-import { api, type GvkRef, type ResourceTable } from "../lib/api";
+import { api, type ResourceTable } from "../lib/api";
 import type { KindEntry } from "../lib/kinds";
 
 vi.mock("../lib/api", async (original) => {
@@ -23,17 +27,15 @@ vi.mock("../lib/api", async (original) => {
       startWatch: vi.fn().mockResolvedValue(1),
       stopWatch: vi.fn().mockResolvedValue(true),
       listTable: vi.fn(),
-      getObject: vi.fn(),
       listNamespaces: vi.fn(),
-      listRelated: vi.fn(),
     },
   };
 });
 
 const listTable = vi.mocked(api.listTable);
-const getObject = vi.mocked(api.getObject);
 const listNamespaces = vi.mocked(api.listNamespaces);
-const listRelated = vi.mocked(api.listRelated);
+
+const onOpen = vi.fn();
 
 function kind(name: string): KindEntry {
   return {
@@ -71,7 +73,7 @@ function renderBrowser(entry: KindEntry) {
   });
   const view = render(
     <QueryClientProvider client={client}>
-      <KindBrowser entry={entry} />
+      <KindBrowser entry={entry} onOpen={onOpen} />
     </QueryClientProvider>,
   );
   return {
@@ -79,34 +81,19 @@ function renderBrowser(entry: KindEntry) {
     switchTo: (next: KindEntry) =>
       view.rerender(
         <QueryClientProvider client={client}>
-          <KindBrowser entry={next} />
+          <KindBrowser entry={next} onOpen={onOpen} />
         </QueryClientProvider>,
       ),
   };
 }
 
 beforeEach(() => {
+  onOpen.mockReset();
   listTable.mockReset();
-  getObject.mockReset();
   listNamespaces.mockReset();
-  listRelated.mockReset();
-  listRelated.mockResolvedValue([]);
 
   listTable.mockResolvedValue(table("mcp-hello"));
   listNamespaces.mockResolvedValue([]);
-  getObject.mockImplementation(async (resource: GvkRef, namespace, name) => ({
-    apiVersion: `${resource.group}/${resource.version}`,
-    kind: resource.kind,
-    name,
-    namespace,
-    age: "65d",
-    status: "Ready",
-    labels: [],
-    annotations: [],
-    conditions: [],
-    editable: true,
-    yaml: `kind: ${resource.kind}\n`,
-  }));
 });
 
 describe("KindBrowser", () => {
@@ -141,33 +128,30 @@ describe("KindBrowser", () => {
     ).toBeInTheDocument();
   });
 
-  it("opens an object from the listing", async () => {
+  it("reports the row it was told to open", async () => {
     const { user } = renderBrowser(AGENT);
     await user.click(await screen.findByText("mcp-hello"));
 
-    await waitFor(() => expect(getObject).toHaveBeenCalled());
-    expect(getObject.mock.calls[0][0].kind).toBe("Agent");
+    await waitFor(() =>
+      expect(onOpen).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "mcp-hello", namespace: "agents" }),
+        "here",
+      ),
+    );
   });
 
-  it("drops the open object when the kind changes underneath it", async () => {
-    // An Agent named mcp-hello is not a Model named mcp-hello. Carrying
-    // the selection across sends the detail view after an object that
-    // does not exist, and the pane renders a 404.
-    const { user, switchTo } = renderBrowser(AGENT);
-    await user.click(await screen.findByText("mcp-hello"));
-    await waitFor(() => expect(getObject).toHaveBeenCalled());
+  it("shows the new kind's own rows when the kind changes underneath it", async () => {
+    // An Agent named mcp-hello is not a Model named mcp-hello, and a
+    // listing that carried the old rows across would be showing one
+    // kind's objects under another's heading.
+    const { switchTo } = renderBrowser(AGENT);
+    await screen.findByText("mcp-hello");
 
     listTable.mockResolvedValue(table("qwen2-0-5b"));
     switchTo(MODEL);
 
-    // Back to a listing, showing the new kind's own objects.
     expect(await screen.findByText("qwen2-0-5b")).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: /Back to/ }),
-    ).not.toBeInTheDocument();
-    expect(
-      getObject.mock.calls.some(([resource]) => resource.kind === "Model"),
-    ).toBe(false);
+    expect(screen.queryByText("mcp-hello")).not.toBeInTheDocument();
   });
 
   it("asks for one page rather than the whole cluster", async () => {
@@ -211,65 +195,5 @@ describe("KindBrowser", () => {
     expect(await screen.findByText("second-page-agent")).toBeInTheDocument();
     // The first page is still there; pages accumulate rather than replace.
     expect(screen.getByText("first-page-agent")).toBeInTheDocument();
-  });
-
-  it("follows a related object into a different kind", async () => {
-    // The whole point of the Related tab. The listing stays on Agents;
-    // the detail view moves to the ConfigMap.
-    listRelated.mockResolvedValue([
-      {
-        relation: "uses",
-        group: "",
-        version: "v1",
-        kind: "ConfigMap",
-        name: "agent-config",
-        namespace: "agents",
-        reachable: true,
-        detail: "volume config",
-      },
-    ]);
-
-    const { user } = renderBrowser(AGENT);
-    await user.click(await screen.findByText("mcp-hello"));
-    await waitFor(() => expect(getObject).toHaveBeenCalled());
-
-    await user.click(await screen.findByRole("button", { name: "Related" }));
-    await user.click(await screen.findByRole("button", { name: /agent-config/ }));
-
-    await waitFor(() =>
-      expect(
-        getObject.mock.calls.some(([resource]) => resource.kind === "ConfigMap"),
-      ).toBe(true),
-    );
-  });
-
-  it("goes back to where it was followed from, not to the listing", async () => {
-    // Following a chain and then closing should retrace it, or the back
-    // button loses everything you navigated through.
-    listRelated.mockResolvedValue([
-      {
-        relation: "uses",
-        group: "",
-        version: "v1",
-        kind: "ConfigMap",
-        name: "agent-config",
-        namespace: "agents",
-        reachable: true,
-        detail: null,
-      },
-    ]);
-
-    const { user } = renderBrowser(AGENT);
-    await user.click(await screen.findByText("mcp-hello"));
-    await user.click(await screen.findByRole("button", { name: "Related" }));
-    await user.click(await screen.findByRole("button", { name: /agent-config/ }));
-    await screen.findByRole("button", { name: "Back to mcp-hello" });
-
-    await user.click(screen.getByRole("button", { name: "Back to mcp-hello" }));
-
-    // Back at the Agent, not at the Agents listing.
-    expect(
-      await screen.findByRole("button", { name: "Back to agent" }),
-    ).toBeInTheDocument();
   });
 });

--- a/src/pages/KindBrowser.test.tsx
+++ b/src/pages/KindBrowser.test.tsx
@@ -12,6 +12,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { KindBrowser } from "./KindBrowser";
 import { api, type ResourceTable } from "../lib/api";
 import type { KindEntry } from "../lib/kinds";
+import type { ListView } from "../lib/routes";
 
 vi.mock("../lib/api", async (original) => {
   const actual = await original<typeof import("../lib/api")>();
@@ -36,6 +37,7 @@ const listTable = vi.mocked(api.listTable);
 const listNamespaces = vi.mocked(api.listNamespaces);
 
 const onOpen = vi.fn();
+const onView = vi.fn();
 
 function kind(name: string): KindEntry {
   return {
@@ -67,13 +69,18 @@ function table(rowName: string): ResourceTable {
   };
 }
 
-function renderBrowser(entry: KindEntry) {
+function renderBrowser(entry: KindEntry, listView: ListView = {}) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   const view = render(
     <QueryClientProvider client={client}>
-      <KindBrowser entry={entry} onOpen={onOpen} />
+      <KindBrowser
+        entry={entry}
+        onOpen={onOpen}
+        view={listView}
+        onView={onView}
+      />
     </QueryClientProvider>,
   );
   return {
@@ -81,7 +88,7 @@ function renderBrowser(entry: KindEntry) {
     switchTo: (next: KindEntry) =>
       view.rerender(
         <QueryClientProvider client={client}>
-          <KindBrowser entry={next} onOpen={onOpen} />
+          <KindBrowser entry={next} onOpen={onOpen} view={{}} onView={onView} />
         </QueryClientProvider>,
       ),
   };
@@ -89,6 +96,7 @@ function renderBrowser(entry: KindEntry) {
 
 beforeEach(() => {
   onOpen.mockReset();
+  onView.mockReset();
   listTable.mockReset();
   listNamespaces.mockReset();
 
@@ -113,6 +121,12 @@ describe("KindBrowser", () => {
     ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("checkbox", { name: /wide/i }));
+    expect(onView).toHaveBeenCalledWith({ wide: true });
+  });
+
+  it("shows the wide columns when the view asks for them", async () => {
+    renderBrowser(AGENT, { wide: true });
+    await screen.findByText("mcp-hello");
     expect(
       screen.getByRole("columnheader", { name: "Selector" }),
     ).toBeInTheDocument();

--- a/src/pages/KindBrowser.tsx
+++ b/src/pages/KindBrowser.tsx
@@ -1,81 +1,36 @@
-import { useState } from "react";
 import { TableBrowser } from "../components/TableBrowser";
-import { ObjectDetail } from "./ObjectDetail";
 import type { KindEntry } from "../lib/kinds";
-import type { GvkRef, TableRow } from "../lib/api";
+import type { OpenIntent } from "../lib/routes";
+import type { TableRow } from "../lib/api";
 
-// One kind: its listing, and whichever object is open from it.
+// One kind's listing, with the columns the API server printed.
 //
 // Every sidebar entry below Cluster lands here, and so does every custom
 // resource. Nothing in this file knows what kind it is showing — the
-// listing's columns come from the API server and the detail view reads
-// whatever the object turns out to have.
+// columns come from the server.
 //
-// What is open is held as a full descriptor rather than as a row from
-// the table, because following a related object leaves the kind the
-// listing is showing: from a Deployment you reach its ReplicaSet, from
-// there its Pods, and from a Pod the ConfigMap it mounts. The listing
-// stays put; only the detail view moves.
+// This used to hold the object open from the listing, and a linked list
+// of the ones opened before it, because following a related object
+// leaves the kind the listing shows: from a Deployment you reach its
+// ReplicaSet, from there its Pods, and from a Pod the ConfigMap it
+// mounts. That chain is now the tab's history, which means it can be
+// walked forwards as well as back, survives switching to another tab,
+// and is the same mechanism whether the chain started here or in the
+// pod list.
 
-interface Open {
-  resource: GvkRef;
-  namespace: string | null;
-  name: string;
-  /// What the back button returns to. Once you have followed a chain,
-  /// that is the object you came from rather than the listing.
-  backTo: string;
-  /// Where to return to on close. Null returns to the listing.
-  from: Open | null;
-}
-
-export function KindBrowser({ entry }: { entry: KindEntry }) {
-  const [open, setOpen] = useState<Open | null>(null);
-  const [shown, setShown] = useState(entry.id);
-
-  // Changing kinds drops whatever was open. An Agent named mcp-hello is
-  // not a Model named mcp-hello, and carrying the selection across would
-  // send the detail view looking for an object that does not exist.
-  //
-  // Done here rather than with a `key` on the caller, so the guarantee
-  // belongs to the component that holds the state instead of to every
-  // place that renders it. Adjusting state during render is React's own
-  // recommendation for this, and costs no extra paint.
-  if (shown !== entry.id) {
-    setShown(entry.id);
-    setOpen(null);
-    return null;
-  }
-
-  if (open) {
-    return (
-      <ObjectDetail
-        // Keyed so following a related object remounts rather than
-        // showing the previous object's tab state over the new one.
-        key={`${open.resource.kind}/${open.namespace ?? ""}/${open.name}`}
-        resource={open.resource}
-        namespace={open.namespace}
-        name={open.name}
-        backTo={open.backTo}
-        onClose={() => setOpen(open.from)}
-        onOpenRelated={(related) =>
-          setOpen({
-            resource: {
-              group: related.group,
-              version: related.version,
-              kind: related.kind,
-            },
-            namespace: related.namespace,
-            name: related.name,
-            backTo: open.name,
-            from: open,
-          })
-        }
-      />
-    );
-  }
-
+export function KindBrowser({
+  entry,
+  onOpen,
+}: {
+  entry: KindEntry;
+  onOpen: (row: TableRow, intent: OpenIntent) => void;
+}) {
   return (
     <TableBrowser
+      // Keyed on the kind so switching kinds refetches and resets the
+      // namespace filter rather than showing one kind's rows under
+      // another's heading for a frame.
+      key={entry.id}
       resource={entry.gvk}
       title={entry.label}
       subtitle={
@@ -83,15 +38,7 @@ export function KindBrowser({ entry }: { entry: KindEntry }) {
           ? `${entry.gvk.group}/${entry.gvk.version}`
           : `core/${entry.gvk.version}`
       }
-      onOpen={(row: TableRow) =>
-        setOpen({
-          resource: entry.gvk,
-          namespace: row.namespace,
-          name: row.name,
-          backTo: entry.label.toLowerCase(),
-          from: null,
-        })
-      }
+      onOpen={onOpen}
     />
   );
 }

--- a/src/pages/KindBrowser.tsx
+++ b/src/pages/KindBrowser.tsx
@@ -1,6 +1,6 @@
 import { TableBrowser } from "../components/TableBrowser";
 import type { KindEntry } from "../lib/kinds";
-import type { OpenIntent } from "../lib/routes";
+import type { ListView, OpenIntent } from "../lib/routes";
 import type { TableRow } from "../lib/api";
 
 // One kind's listing, with the columns the API server printed.
@@ -21,9 +21,13 @@ import type { TableRow } from "../lib/api";
 export function KindBrowser({
   entry,
   onOpen,
+  view,
+  onView,
 }: {
   entry: KindEntry;
   onOpen: (row: TableRow, intent: OpenIntent) => void;
+  view: ListView;
+  onView: (patch: Partial<ListView>) => void;
 }) {
   return (
     <TableBrowser
@@ -39,6 +43,8 @@ export function KindBrowser({
           : `core/${entry.gvk.version}`
       }
       onOpen={onOpen}
+      view={view}
+      onView={onView}
     />
   );
 }

--- a/src/pages/NamespaceDetail.tsx
+++ b/src/pages/NamespaceDetail.tsx
@@ -125,7 +125,6 @@ export function NamespaceDetail({
       tab={tab}
       onTab={setTab}
       onClose={onClose}
-      backTo="namespaces"
       error={q.error}
     >
       {tab === "overview" &&

--- a/src/pages/NodeDetail.tsx
+++ b/src/pages/NodeDetail.tsx
@@ -135,7 +135,6 @@ export function NodeDetail({ name, onClose }: NodeDetailProps) {
       tab={tab}
       onTab={setTab}
       onClose={onClose}
-      backTo="nodes"
       error={q.error}
       actions={
         node && (

--- a/src/pages/ObjectDetail.tsx
+++ b/src/pages/ObjectDetail.tsx
@@ -71,7 +71,6 @@ interface ObjectDetailProps {
   namespace: string | null;
   name: string;
   onClose: () => void;
-  backTo?: string;
   /// Opens another object from the Related tab. Without it the tab is a
   /// list you cannot follow, which is most of the point gone, so the
   /// tab is only offered when a caller can navigate.
@@ -83,7 +82,6 @@ export function ObjectDetail({
   namespace,
   name,
   onClose,
-  backTo,
   onOpenRelated,
 }: ObjectDetailProps) {
   const [tab, setTab] = useState("overview");
@@ -144,7 +142,6 @@ export function ObjectDetail({
       tab={tab}
       onTab={setTab}
       onClose={onClose}
-      backTo={backTo}
       error={q.error}
       actions={
         object && (

--- a/src/pages/PodDetail.tsx
+++ b/src/pages/PodDetail.tsx
@@ -95,7 +95,6 @@ export function PodDetail({ namespace, name, onClose }: PodDetailProps) {
       tab={tab}
       onTab={setTab}
       onClose={onClose}
-      backTo="pods"
       error={q.error}
       actions={
         pod && (

--- a/src/pages/Resources.test.tsx
+++ b/src/pages/Resources.test.tsx
@@ -6,9 +6,10 @@ import type { ReactElement } from "react";
 import { Namespaces, Nodes, Pods } from "./Resources";
 import { api, type NodeSummary, type PodSummary } from "../lib/api";
 
-// The three built-in list views. Each is a table plus a detail view it
-// swaps to, so what is worth covering is the columns an operator scans,
-// and that clicking a row opens the right object.
+// The three built-in list views. Each is a listing and nothing else —
+// what it does with a row is the workspace's business — so what is worth
+// covering is the columns an operator scans, and that a click reports
+// the right object and the right intent.
 
 vi.mock("../lib/api", async (original) => {
   const actual = await original<typeof import("../lib/api")>();
@@ -22,11 +23,6 @@ vi.mock("../lib/api", async (original) => {
       listNodes: vi.fn(),
       listNamespaces: vi.fn(),
       listPods: vi.fn(),
-      getNode: vi.fn(),
-      getNamespace: vi.fn(),
-      getPod: vi.fn(),
-      listPodsOnNode: vi.fn(),
-      listEvents: vi.fn(),
     },
   };
 });
@@ -34,8 +30,8 @@ vi.mock("../lib/api", async (original) => {
 const listNodes = vi.mocked(api.listNodes);
 const listNamespaces = vi.mocked(api.listNamespaces);
 const listPods = vi.mocked(api.listPods);
-const getNode = vi.mocked(api.getNode);
-const getPod = vi.mocked(api.getPod);
+
+const onOpen = vi.fn();
 
 function pod(overrides: Partial<PodSummary> = {}): PodSummary {
   return {
@@ -70,23 +66,17 @@ function renderPage(page: ReactElement) {
 }
 
 beforeEach(() => {
-  vi.mocked(api.listEvents).mockResolvedValue([]);
-  vi.mocked(api.listPodsOnNode).mockResolvedValue([]);
-
+  onOpen.mockReset();
   listNodes.mockReset().mockResolvedValue([node()]);
   listNamespaces
     .mockReset()
     .mockResolvedValue([{ name: "prod", phase: "Active", age: "120d" }]);
   listPods.mockReset().mockResolvedValue([pod()]);
-
-  getNode.mockReset();
-  getPod.mockReset();
-  vi.mocked(api.getNamespace).mockReset();
 });
 
 describe("Nodes", () => {
   it("lists nodes with their roles and readiness", async () => {
-    renderPage(<Nodes />);
+    renderPage(<Nodes onOpen={onOpen} />);
     expect(await screen.findByText("worker-1")).toBeInTheDocument();
     expect(screen.getByText("Ready")).toBeInTheDocument();
     expect(screen.getByText("worker")).toBeInTheDocument();
@@ -95,22 +85,26 @@ describe("Nodes", () => {
 
   it("says NotReady rather than leaving the cell blank", async () => {
     listNodes.mockResolvedValue([node({ ready: false })]);
-    renderPage(<Nodes />);
+    renderPage(<Nodes onOpen={onOpen} />);
     expect(await screen.findByText("NotReady")).toBeInTheDocument();
   });
 
   it("renders an em dash for a node with no age", async () => {
     listNodes.mockResolvedValue([node({ age: null })]);
-    renderPage(<Nodes />);
+    renderPage(<Nodes onOpen={onOpen} />);
     expect(await screen.findByText("—")).toBeInTheDocument();
   });
 
-  it("opens the node it was told to", async () => {
-    getNode.mockImplementation(() => new Promise(() => {}));
-    const user = renderPage(<Nodes />);
+  it("reports the node it was told to open", async () => {
+    const user = renderPage(<Nodes onOpen={onOpen} />);
     await user.click(await screen.findByText("worker-1"));
 
-    await waitFor(() => expect(getNode).toHaveBeenCalledWith("worker-1"));
+    await waitFor(() =>
+      expect(onOpen).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "worker-1" }),
+        "here",
+      ),
+    );
   });
 
   it("surfaces a failure to list", async () => {
@@ -118,32 +112,34 @@ describe("Nodes", () => {
       kind: "kubernetes",
       message: 'nodes is forbidden: User "dev" cannot list resource "nodes"',
     });
-    renderPage(<Nodes />);
+    renderPage(<Nodes onOpen={onOpen} />);
     expect(await screen.findByText(/forbidden/)).toBeInTheDocument();
   });
 });
 
 describe("Namespaces", () => {
   it("lists namespaces with their phase", async () => {
-    renderPage(<Namespaces />);
+    renderPage(<Namespaces onOpen={onOpen} />);
     expect(await screen.findByText("prod")).toBeInTheDocument();
     expect(screen.getByText("Active")).toBeInTheDocument();
   });
 
-  it("opens the namespace it was told to", async () => {
-    vi.mocked(api.getNamespace).mockImplementation(() => new Promise(() => {}));
-    const user = renderPage(<Namespaces />);
+  it("reports the namespace it was told to open", async () => {
+    const user = renderPage(<Namespaces onOpen={onOpen} />);
     await user.click(await screen.findByText("prod"));
 
     await waitFor(() =>
-      expect(api.getNamespace).toHaveBeenCalledWith("prod"),
+      expect(onOpen).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "prod" }),
+        "here",
+      ),
     );
   });
 });
 
 describe("Pods", () => {
   it("shows the columns an operator scans", async () => {
-    renderPage(<Pods />);
+    renderPage(<Pods onOpen={onOpen} />);
     expect(await screen.findByText("web-abc")).toBeInTheDocument();
     expect(screen.getByText("1/1")).toBeInTheDocument();
     expect(screen.getByText("worker-1")).toBeInTheDocument();
@@ -153,7 +149,7 @@ describe("Pods", () => {
   it("does not draw attention to a pod that has not restarted", async () => {
     // A coloured 0 on every healthy row would train people to ignore
     // the column that matters.
-    renderPage(<Pods />);
+    renderPage(<Pods onOpen={onOpen} />);
     const zero = await screen.findByText("0");
     expect(zero).toHaveClass("text-content-muted");
   });
@@ -162,40 +158,58 @@ describe("Pods", () => {
     // Above five restarts the pod is not merely flapping; the column is
     // scanned for exactly this.
     listPods.mockResolvedValue([pod({ restarts: 12 })]);
-    renderPage(<Pods />);
+    renderPage(<Pods onOpen={onOpen} />);
     expect(await screen.findByText("12")).toHaveClass("text-danger");
   });
 
   it("lists every namespace by default", async () => {
     // Matching `kubectl get pods -A`, which is what the cluster-wide
     // view is for.
-    renderPage(<Pods />);
+    renderPage(<Pods onOpen={onOpen} />);
     await screen.findByText("web-abc");
     expect(listPods).toHaveBeenCalledWith(undefined);
     expect(screen.getByText("All namespaces")).toBeInTheDocument();
   });
 
   it("narrows to one namespace when picked", async () => {
-    const user = renderPage(<Pods />);
+    const user = renderPage(<Pods onOpen={onOpen} />);
     await screen.findByText("web-abc");
 
     await user.selectOptions(screen.getByRole("combobox"), "prod");
     await waitFor(() => expect(listPods).toHaveBeenCalledWith("prod"));
   });
 
-  it("opens the pod it was told to, with its namespace", async () => {
+  it("reports the pod it was told to open, with its namespace", async () => {
     // A pod is identified by both. Opening on the name alone would find
     // the wrong pod wherever a name repeats across namespaces.
-    getPod.mockImplementation(() => new Promise(() => {}));
-    const user = renderPage(<Pods />);
+    const user = renderPage(<Pods onOpen={onOpen} />);
     await user.click(await screen.findByText("web-abc"));
 
-    await waitFor(() => expect(getPod).toHaveBeenCalledWith("prod", "web-abc"));
+    await waitFor(() =>
+      expect(onOpen).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "web-abc", namespace: "prod" }),
+        "here",
+      ),
+    );
+  });
+
+  it("asks for a new tab when the row is opened with the modifier held", async () => {
+    // The convention a link follows everywhere else, and what lets a
+    // listing be fanned out without returning to it between each one.
+    const user = renderPage(<Pods onOpen={onOpen} />);
+    const row = await screen.findByText("web-abc");
+    await user.keyboard("{Meta>}");
+    await user.click(row);
+    await user.keyboard("{/Meta}");
+
+    await waitFor(() =>
+      expect(onOpen).toHaveBeenCalledWith(expect.anything(), "newTab"),
+    );
   });
 
   it("says so when nothing is visible", async () => {
     listPods.mockResolvedValue([]);
-    renderPage(<Pods />);
+    renderPage(<Pods onOpen={onOpen} />);
     expect(await screen.findByText("No pods visible.")).toBeInTheDocument();
   });
 });

--- a/src/pages/Resources.test.tsx
+++ b/src/pages/Resources.test.tsx
@@ -32,6 +32,7 @@ const listNamespaces = vi.mocked(api.listNamespaces);
 const listPods = vi.mocked(api.listPods);
 
 const onOpen = vi.fn();
+const onView = vi.fn();
 
 function pod(overrides: Partial<PodSummary> = {}): PodSummary {
   return {
@@ -67,6 +68,7 @@ function renderPage(page: ReactElement) {
 
 beforeEach(() => {
   onOpen.mockReset();
+  onView.mockReset();
   listNodes.mockReset().mockResolvedValue([node()]);
   listNamespaces
     .mockReset()
@@ -76,7 +78,7 @@ beforeEach(() => {
 
 describe("Nodes", () => {
   it("lists nodes with their roles and readiness", async () => {
-    renderPage(<Nodes onOpen={onOpen} />);
+    renderPage(<Nodes onOpen={onOpen} view={{}} onView={onView} />);
     expect(await screen.findByText("worker-1")).toBeInTheDocument();
     expect(screen.getByText("Ready")).toBeInTheDocument();
     expect(screen.getByText("worker")).toBeInTheDocument();
@@ -85,18 +87,18 @@ describe("Nodes", () => {
 
   it("says NotReady rather than leaving the cell blank", async () => {
     listNodes.mockResolvedValue([node({ ready: false })]);
-    renderPage(<Nodes onOpen={onOpen} />);
+    renderPage(<Nodes onOpen={onOpen} view={{}} onView={onView} />);
     expect(await screen.findByText("NotReady")).toBeInTheDocument();
   });
 
   it("renders an em dash for a node with no age", async () => {
     listNodes.mockResolvedValue([node({ age: null })]);
-    renderPage(<Nodes onOpen={onOpen} />);
+    renderPage(<Nodes onOpen={onOpen} view={{}} onView={onView} />);
     expect(await screen.findByText("—")).toBeInTheDocument();
   });
 
   it("reports the node it was told to open", async () => {
-    const user = renderPage(<Nodes onOpen={onOpen} />);
+    const user = renderPage(<Nodes onOpen={onOpen} view={{}} onView={onView} />);
     await user.click(await screen.findByText("worker-1"));
 
     await waitFor(() =>
@@ -112,20 +114,20 @@ describe("Nodes", () => {
       kind: "kubernetes",
       message: 'nodes is forbidden: User "dev" cannot list resource "nodes"',
     });
-    renderPage(<Nodes onOpen={onOpen} />);
+    renderPage(<Nodes onOpen={onOpen} view={{}} onView={onView} />);
     expect(await screen.findByText(/forbidden/)).toBeInTheDocument();
   });
 });
 
 describe("Namespaces", () => {
   it("lists namespaces with their phase", async () => {
-    renderPage(<Namespaces onOpen={onOpen} />);
+    renderPage(<Namespaces onOpen={onOpen} view={{}} onView={onView} />);
     expect(await screen.findByText("prod")).toBeInTheDocument();
     expect(screen.getByText("Active")).toBeInTheDocument();
   });
 
   it("reports the namespace it was told to open", async () => {
-    const user = renderPage(<Namespaces onOpen={onOpen} />);
+    const user = renderPage(<Namespaces onOpen={onOpen} view={{}} onView={onView} />);
     await user.click(await screen.findByText("prod"));
 
     await waitFor(() =>
@@ -139,7 +141,7 @@ describe("Namespaces", () => {
 
 describe("Pods", () => {
   it("shows the columns an operator scans", async () => {
-    renderPage(<Pods onOpen={onOpen} />);
+    renderPage(<Pods onOpen={onOpen} view={{}} onView={onView} />);
     expect(await screen.findByText("web-abc")).toBeInTheDocument();
     expect(screen.getByText("1/1")).toBeInTheDocument();
     expect(screen.getByText("worker-1")).toBeInTheDocument();
@@ -149,7 +151,7 @@ describe("Pods", () => {
   it("does not draw attention to a pod that has not restarted", async () => {
     // A coloured 0 on every healthy row would train people to ignore
     // the column that matters.
-    renderPage(<Pods onOpen={onOpen} />);
+    renderPage(<Pods onOpen={onOpen} view={{}} onView={onView} />);
     const zero = await screen.findByText("0");
     expect(zero).toHaveClass("text-content-muted");
   });
@@ -158,31 +160,43 @@ describe("Pods", () => {
     // Above five restarts the pod is not merely flapping; the column is
     // scanned for exactly this.
     listPods.mockResolvedValue([pod({ restarts: 12 })]);
-    renderPage(<Pods onOpen={onOpen} />);
+    renderPage(<Pods onOpen={onOpen} view={{}} onView={onView} />);
     expect(await screen.findByText("12")).toHaveClass("text-danger");
   });
 
   it("lists every namespace by default", async () => {
     // Matching `kubectl get pods -A`, which is what the cluster-wide
     // view is for.
-    renderPage(<Pods onOpen={onOpen} />);
+    renderPage(<Pods onOpen={onOpen} view={{}} onView={onView} />);
     await screen.findByText("web-abc");
     expect(listPods).toHaveBeenCalledWith(undefined);
     expect(screen.getByText("All namespaces")).toBeInTheDocument();
   });
 
-  it("narrows to one namespace when picked", async () => {
-    const user = renderPage(<Pods onOpen={onOpen} />);
+  it("reports the namespace it was asked to narrow to", async () => {
+    // The page reports; where that is kept is the workspace's business.
+    // Holding it here is what used to make the filter evaporate the
+    // moment you opened a pod from the list.
+    const user = renderPage(<Pods onOpen={onOpen} view={{}} onView={onView} />);
     await screen.findByText("web-abc");
 
     await user.selectOptions(screen.getByRole("combobox"), "prod");
+    await waitFor(() => expect(onView).toHaveBeenCalledWith({ namespace: "prod" }));
+  });
+
+  it("asks the cluster for the namespace the view names", async () => {
+    renderPage(
+      <Pods onOpen={onOpen} view={{ namespace: "prod" }} onView={onView} />,
+    );
     await waitFor(() => expect(listPods).toHaveBeenCalledWith("prod"));
+    // And the picker shows it, once the namespace list has arrived.
+    await waitFor(() => expect(screen.getByRole("combobox")).toHaveValue("prod"));
   });
 
   it("reports the pod it was told to open, with its namespace", async () => {
     // A pod is identified by both. Opening on the name alone would find
     // the wrong pod wherever a name repeats across namespaces.
-    const user = renderPage(<Pods onOpen={onOpen} />);
+    const user = renderPage(<Pods onOpen={onOpen} view={{}} onView={onView} />);
     await user.click(await screen.findByText("web-abc"));
 
     await waitFor(() =>
@@ -196,7 +210,7 @@ describe("Pods", () => {
   it("asks for a new tab when the row is opened with the modifier held", async () => {
     // The convention a link follows everywhere else, and what lets a
     // listing be fanned out without returning to it between each one.
-    const user = renderPage(<Pods onOpen={onOpen} />);
+    const user = renderPage(<Pods onOpen={onOpen} view={{}} onView={onView} />);
     const row = await screen.findByText("web-abc");
     await user.keyboard("{Meta>}");
     await user.click(row);
@@ -209,7 +223,7 @@ describe("Pods", () => {
 
   it("says so when nothing is visible", async () => {
     listPods.mockResolvedValue([]);
-    renderPage(<Pods onOpen={onOpen} />);
+    renderPage(<Pods onOpen={onOpen} view={{}} onView={onView} />);
     expect(await screen.findByText("No pods visible.")).toBeInTheDocument();
   });
 });

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { ResourceTable } from "../components/ResourceTable";
 import { type Column } from "../components/Table";
@@ -12,7 +11,7 @@ import {
   type NodeSummary,
   type PodSummary,
 } from "../lib/api";
-import type { OpenIntent } from "../lib/routes";
+import type { ListView, OpenIntent } from "../lib/routes";
 
 // The three listings that have a view of their own rather than a
 // server-printed table.
@@ -25,6 +24,12 @@ import type { OpenIntent } from "../lib/routes";
 
 interface ListProps<T> {
   onOpen: (target: T, intent: OpenIntent) => void;
+  /// How this listing is presented. Held by the caller, because a
+  /// listing unmounts the moment you open a row from it — and a
+  /// namespace filter that has to be re-picked every time you look at a
+  /// pod is worse than no filter at all.
+  view: ListView;
+  onView: (patch: Partial<ListView>) => void;
 }
 
 /// Worst first. Sorting a status column alphabetically puts Failed
@@ -32,7 +37,7 @@ interface ListProps<T> {
 /// what the tone already says about how much attention it wants.
 const PHASE_ORDER = ["danger", "warn", "ok", "unknown"] as const;
 
-export function Nodes({ onOpen }: ListProps<NodeSummary>) {
+export function Nodes({ onOpen, view, onView }: ListProps<NodeSummary>) {
   const q = useQuery({
     queryKey: ["nodes"],
     queryFn: () => api.listNodes(),
@@ -92,12 +97,14 @@ export function Nodes({ onOpen }: ListProps<NodeSummary>) {
         searchText={(n) => `${n.name} ${n.roles.join(" ")} ${n.version}`}
         empty="No nodes visible."
         onRowClick={onOpen}
+        view={view}
+        onView={onView}
       />
     </Panel>
   );
 }
 
-export function Namespaces({ onOpen }: ListProps<NamespaceSummary>) {
+export function Namespaces({ onOpen, view, onView }: ListProps<NamespaceSummary>) {
   const q = useQuery({
     queryKey: ["namespaces"],
     queryFn: () => api.listNamespaces(),
@@ -140,14 +147,17 @@ export function Namespaces({ onOpen }: ListProps<NamespaceSummary>) {
         searchText={(n) => `${n.name} ${n.phase}`}
         empty="No namespaces visible."
         onRowClick={onOpen}
+        view={view}
+        onView={onView}
       />
     </Panel>
   );
 }
 
-export function Pods({ onOpen }: ListProps<PodSummary>) {
+export function Pods({ onOpen, view, onView }: ListProps<PodSummary>) {
   // Empty string means all namespaces, matching kubectl -A.
-  const [namespace, setNamespace] = useState("");
+  const namespace = view.namespace ?? "";
+  const setNamespace = (next: string) => onView({ namespace: next });
 
   const pods = useQuery({
     queryKey: ["pods", namespace],
@@ -231,8 +241,14 @@ export function Pods({ onOpen }: ListProps<PodSummary>) {
         searchText={(p) => `${p.name} ${p.namespace} ${p.phase} ${p.node ?? ""}`}
         empty="No pods visible."
         onRowClick={onOpen}
+        view={view}
+        onView={onView}
         toolbar={
-          <Select value={namespace} onChange={setNamespace}>
+          <Select
+            title="Namespace"
+            value={namespace}
+            onChange={setNamespace}
+          >
             <option value="">All namespaces</option>
             {(namespaces.data ?? []).map((ns) => (
               <option key={ns.name} value={ns.name}>

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -27,6 +27,11 @@ interface ListProps<T> {
   onOpen: (target: T, intent: OpenIntent) => void;
 }
 
+/// Worst first. Sorting a status column alphabetically puts Failed
+/// beside Pending by accident and Running between them; this orders by
+/// what the tone already says about how much attention it wants.
+const PHASE_ORDER = ["danger", "warn", "ok", "unknown"] as const;
+
 export function Nodes({ onOpen }: ListProps<NodeSummary>) {
   const q = useQuery({
     queryKey: ["nodes"],
@@ -34,7 +39,7 @@ export function Nodes({ onOpen }: ListProps<NodeSummary>) {
   });
 
   const columns: Column<NodeSummary>[] = [
-    { key: "name", header: "Name", render: (n) => n.name },
+    { key: "name", header: "Name", render: (n) => n.name, sortValue: (n) => n.name },
     {
       key: "status",
       header: "Status",
@@ -44,6 +49,8 @@ export function Nodes({ onOpen }: ListProps<NodeSummary>) {
           label={n.ready ? "Ready" : "NotReady"}
         />
       ),
+      // NotReady first, because that is the node you are looking for.
+      sortValue: (n) => (n.ready ? 1 : 0),
     },
     {
       key: "roles",
@@ -51,9 +58,22 @@ export function Nodes({ onOpen }: ListProps<NodeSummary>) {
       // Chips rather than a comma-joined string: a node with three
       // roles should read as three things, not one long value.
       render: (n) => <ChipList values={n.roles} tone="accent" />,
+      sortValue: (n) => n.roles.join(" "),
     },
-    { key: "version", header: "Version", render: (n) => n.version, mono: true },
-    { key: "age", header: "Age", render: (n) => n.age ?? "—", mono: true },
+    {
+      key: "version",
+      header: "Version",
+      render: (n) => n.version,
+      mono: true,
+      sortValue: (n) => n.version,
+    },
+    {
+      key: "age",
+      header: "Age",
+      render: (n) => n.age ?? "—",
+      mono: true,
+      sortValue: (n) => n.age,
+    },
   ];
 
   return (
@@ -84,15 +104,24 @@ export function Namespaces({ onOpen }: ListProps<NamespaceSummary>) {
   });
 
   const columns: Column<NamespaceSummary>[] = [
-    { key: "name", header: "Name", render: (n) => n.name },
+    { key: "name", header: "Name", render: (n) => n.name, sortValue: (n) => n.name },
     {
       key: "phase",
       header: "Status",
       render: (n) => (
         <StatusDot tone={n.phase === "Active" ? "ok" : "warn"} label={n.phase} />
       ),
+      // Terminating before Active: a namespace that will not go away is
+      // the one worth finding.
+      sortValue: (n) => (n.phase === "Active" ? 1 : 0),
     },
-    { key: "age", header: "Age", render: (n) => n.age ?? "—", mono: true },
+    {
+      key: "age",
+      header: "Age",
+      render: (n) => n.age ?? "—",
+      mono: true,
+      sortValue: (n) => n.age,
+    },
   ];
 
   return (
@@ -134,14 +163,31 @@ export function Pods({ onOpen }: ListProps<PodSummary>) {
   });
 
   const columns: Column<PodSummary>[] = [
-    { key: "name", header: "Name", render: (p) => p.name },
-    { key: "namespace", header: "Namespace", render: (p) => p.namespace },
+    { key: "name", header: "Name", render: (p) => p.name, sortValue: (p) => p.name },
+    {
+      key: "namespace",
+      header: "Namespace",
+      render: (p) => p.namespace,
+      sortValue: (p) => p.namespace,
+    },
     {
       key: "phase",
       header: "Status",
       render: (p) => <StatusDot tone={phaseTone(p.phase)} label={p.phase} />,
+      // By how much the phase should worry you rather than by its name,
+      // so Failed and Pending come up together ahead of Running instead
+      // of landing either side of it alphabetically.
+      sortValue: (p) => PHASE_ORDER.indexOf(phaseTone(p.phase)),
     },
-    { key: "ready", header: "Ready", render: (p) => p.ready, mono: true },
+    {
+      key: "ready",
+      header: "Ready",
+      render: (p) => p.ready,
+      mono: true,
+      // "0/1" before "2/3" before "1/1" — least ready first, which is
+      // what the column is scanned for.
+      sortValue: (p) => p.ready,
+    },
     {
       key: "restarts",
       header: "Restarts",
@@ -152,9 +198,21 @@ export function Pods({ onOpen }: ListProps<PodSummary>) {
         ) : (
           <span className="text-content-muted">0</span>
         ),
+      sortValue: (p) => p.restarts,
     },
-    { key: "node", header: "Node", render: (p) => p.node ?? "—" },
-    { key: "age", header: "Age", render: (p) => p.age ?? "—", mono: true },
+    {
+      key: "node",
+      header: "Node",
+      render: (p) => p.node ?? "—",
+      sortValue: (p) => p.node,
+    },
+    {
+      key: "age",
+      header: "Age",
+      render: (p) => p.age ?? "—",
+      mono: true,
+      sortValue: (p) => p.age,
+    },
   ];
 
   return (

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -12,13 +12,22 @@ import {
   type NodeSummary,
   type PodSummary,
 } from "../lib/api";
-import { PodDetail } from "./PodDetail";
-import { NodeDetail } from "./NodeDetail";
-import { NamespaceDetail } from "./NamespaceDetail";
+import type { OpenIntent } from "../lib/routes";
 
-export function Nodes() {
-  const [selected, setSelected] = useState<string | null>(null);
+// The three listings that have a view of their own rather than a
+// server-printed table.
+//
+// Each one is now a listing and nothing else: what happens when a row is
+// opened is the workspace's business, so the same row can go to this tab
+// or to a new one, and the trail behind it survives. Previously each of
+// these held a `selected` and swapped itself for a detail view, which is
+// why there was nothing to go back to.
 
+interface ListProps<T> {
+  onOpen: (target: T, intent: OpenIntent) => void;
+}
+
+export function Nodes({ onOpen }: ListProps<NodeSummary>) {
   const q = useQuery({
     queryKey: ["nodes"],
     queryFn: () => api.listNodes(),
@@ -47,10 +56,6 @@ export function Nodes() {
     { key: "age", header: "Age", render: (n) => n.age ?? "—", mono: true },
   ];
 
-  if (selected) {
-    return <NodeDetail name={selected} onClose={() => setSelected(null)} />;
-  }
-
   return (
     <Panel
       title="Nodes"
@@ -66,15 +71,13 @@ export function Nodes() {
         rowKey={(n) => n.name}
         searchText={(n) => `${n.name} ${n.roles.join(" ")} ${n.version}`}
         empty="No nodes visible."
-        onRowClick={(n) => setSelected(n.name)}
+        onRowClick={onOpen}
       />
     </Panel>
   );
 }
 
-export function Namespaces() {
-  const [selected, setSelected] = useState<string | null>(null);
-
+export function Namespaces({ onOpen }: ListProps<NamespaceSummary>) {
   const q = useQuery({
     queryKey: ["namespaces"],
     queryFn: () => api.listNamespaces(),
@@ -92,12 +95,6 @@ export function Namespaces() {
     { key: "age", header: "Age", render: (n) => n.age ?? "—", mono: true },
   ];
 
-  if (selected) {
-    return (
-      <NamespaceDetail name={selected} onClose={() => setSelected(null)} />
-    );
-  }
-
   return (
     <Panel
       title="Namespaces"
@@ -113,19 +110,15 @@ export function Namespaces() {
         rowKey={(n) => n.name}
         searchText={(n) => `${n.name} ${n.phase}`}
         empty="No namespaces visible."
-        onRowClick={(n) => setSelected(n.name)}
+        onRowClick={onOpen}
       />
     </Panel>
   );
 }
 
-export function Pods() {
+export function Pods({ onOpen }: ListProps<PodSummary>) {
   // Empty string means all namespaces, matching kubectl -A.
   const [namespace, setNamespace] = useState("");
-  const [selected, setSelected] = useState<{
-    namespace: string;
-    name: string;
-  } | null>(null);
 
   const pods = useQuery({
     queryKey: ["pods", namespace],
@@ -164,16 +157,6 @@ export function Pods() {
     { key: "age", header: "Age", render: (p) => p.age ?? "—", mono: true },
   ];
 
-  if (selected) {
-    return (
-      <PodDetail
-        namespace={selected.namespace}
-        name={selected.name}
-        onClose={() => setSelected(null)}
-      />
-    );
-  }
-
   return (
     <Panel
       title="Pods"
@@ -189,7 +172,7 @@ export function Pods() {
         rowKey={(p) => `${p.namespace}/${p.name}`}
         searchText={(p) => `${p.name} ${p.namespace} ${p.phase} ${p.node ?? ""}`}
         empty="No pods visible."
-        onRowClick={(p) => setSelected({ namespace: p.namespace, name: p.name })}
+        onRowClick={onOpen}
         toolbar={
           <Select value={namespace} onChange={setNamespace}>
             <option value="">All namespaces</option>

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -12,11 +12,20 @@
 
 :root {
   /* Neutrals carry a slight blue cast. Pure grey next to the indigo
-     accent reads as dirty; the cast keeps the whole surface coherent. */
-  --base: 242 244 248;
+     accent reads as dirty; the cast keeps the whole surface coherent.
+     Content is the exception and is deliberately paper-white: it is the
+     plane you read a table off, and it should be the brightest thing on
+     screen.
+   *
+   * The ladder runs base → glass → content, in that order of lightness,
+   * and it has to stay in that order. It did not before: content had no
+   * surface of its own, so a table sat on `base` while every bar of
+   * chrome around it was 72% white — which put the chrome in front of
+   * the data and left the largest area on screen the dullest. */
+  --base: 237 240 246;
   --surface-1: 255 255 255;
-  --surface-2: 255 255 255;
-  --surface-3: 236 239 244;
+  --surface-2: 248 250 253;
+  --surface-3: 238 241 247;
 
   --border: 15 23 42;
   --border-alpha: 0.09;
@@ -36,8 +45,12 @@
 
   /* Glass: how much of the layer beneath shows through, and how hard
      the highlight along its top edge is. Tuned separately per theme
-     because translucency reads very differently on light and dark. */
-  --glass-bg: 255 255 255;
+     because translucency reads very differently on light and dark.
+   *
+     Tinted toward the base rather than to pure white. Chrome is the
+     frame, so it belongs between the ground and the content — white
+     glass over a light base lands brighter than the content it frames. */
+  --glass-bg: 247 249 252;
   --glass-alpha: 0.72;
   --glass-highlight: 0.9;
   --glass-blur: 20px;
@@ -78,10 +91,14 @@
 }
 
 .dark {
+  /* Same ladder, same order: base → glass → content. Dark had it very
+     nearly flat — glass composited to within a level or two of
+     surface-1 — so the content plane is lifted and the chrome dimmed
+     until the three are distinguishable. */
   --base: 9 11 16;
-  --surface-1: 15 18 25;
-  --surface-2: 20 24 33;
-  --surface-3: 27 32 43;
+  --surface-1: 17 21 29;
+  --surface-2: 23 27 37;
+  --surface-3: 30 35 47;
 
   --border: 255 255 255;
   --border-alpha: 0.08;
@@ -99,7 +116,7 @@
   --danger: 251 113 133;
   --info: 56 189 248;
 
-  --glass-bg: 20 24 33;
+  --glass-bg: 15 18 26;
   --glass-alpha: 0.62;
   --glass-highlight: 0.06;
   --glass-blur: 24px;
@@ -127,9 +144,16 @@
  * and the OS is blurring the desktop behind us — the opaque background
  * has to get out of the way. Set by the Rust side on startup so the
  * frontend never guesses at platform support.
+ *
+ * It is the window's ground that gets out of the way, not the content.
+ * This used to repoint `--surface-1` at the glass colour, which was
+ * harmless only because nothing painted with surface-1; now that it is
+ * the plane a table is read off, turning it translucent would put the
+ * desktop behind the data and undo the reason it has a surface at all.
+ * The chrome is already glass in its own right, through `.glass`.
  */
 .vibrancy {
-  --surface-1: var(--glass-bg);
+  --base: var(--glass-bg);
 }
 
 /* Translucent, not transparent. A fully transparent body leaves the


### PR DESCRIPTION
Turns Loupe's single pane into a shell that holds work, then fixes what
that exposed.

Loupe rendered exactly one view, and a detail page replaced the listing
underneath it. Opening a pod lost the list it came from, following a
related object was a one-way trip, and two objects could not be held
side by side. That is a browser. This makes it a workbench.

## The shell

Navigation is now central and pure. A **route** is every destination the
app has, a **tab** is a history of routes and a cursor into it, and a
**workspace** is the tabs plus which one is on screen — all in
`lib/routes.ts` and `lib/workspace.ts`, testable without rendering
anything. Pages that held their own `selected` state are listings again:
they report what was opened and let the workspace decide what it means.

- **Tabs** — ⌘T, ⌘W, ⌘1–9, and ⌘-click a row to open it in one of its
  own. The last tab resets rather than closing, because a window with
  nothing open has nowhere to render.
- **Back and forward**, per tab. `KindBrowser`'s hand-rolled linked list
  of previously-opened objects is gone; the same chain is the tab's
  history, so it walks forwards too and survives switching away.
- **A status bar.** The cluster, its guard and the version moved out of
  the foot of the nav rail — a reader three panes deep into a manifest
  has no reason to look back at the navigation to find out which cluster
  they are about to write to. The bar takes the guard's colour.

## Then, what the shell exposed

**Sortable columns.** A string sort is wrong for almost every column
these tables have: `10m` sorts before `2d`, `1/1` and `0/3` compare as
text, `pod-10` lands before `pod-2`. `lib/sort.ts` reads ages as
durations, ready counts as fractions, numbers as numbers, and falls back
to a natural comparison. Sorting happens after the search and before
paging, and a sort over a partly loaded listing says so — it hides that
better than a search does, because the rows come back convincingly
ordered with the real top of the list still on the server.

**Content in front of the chrome.** The surface ramp was defined and
never painted: `bg-surface-1` appeared once in the whole app, and in
light mode surfaces 1 and 2 were both pure white. So the table body fell
through to the window base while every bar of chrome around it was 72%
white — figure and ground the wrong way round, with the largest area on
screen the dullest. The ladder now runs base → glass → content in both
themes.

**Breadcrumbs that describe, not recount.** They were the tab's visited
history, so wandering produced `Nodes › Pods › some-pod › Jobs ›
DaemonSets › some-daemonset` — six steps, none containing the next, in
the one element whose whole meaning is containment. They are derived
from the current route now: kind, namespace, name.

**Filters that survive.** Scoping Pods to a namespace, opening one, and
pressing back handed you every namespace again. A regression from the
refactor — the listing used to stay mounted. How a listing is presented
rides on the route now, so history carries it and two tabs on the same
kind can be scoped differently.

**Interface zoom.** ⌘+ / ⌘− / ⌘0, from the View menu, the keyboard, or
the palette, remembered across launches. Loupe draws at 13px and the
only previous answer was the OS-wide display scale.

## Notes for review

- The **native menu is macOS-only**, and is the one thing here not
  verified by a test or in a browser — it needs a real Tauri window.
  Worth checking under `pnpm tauri dev` that the accelerators parse and
  that Edit still works, since setting a menu replaces Tauri's default
  wholesale.
- The **vibrancy override** moved from `--surface-1` to `--base`. It was
  a no-op while nothing painted with surface-1; now that surface-1 is the
  plane a table is read off, leaving it would have put the desktop behind
  the data.
- The namespace picker had **no accessible name** and now has one.

664 frontend tests and 303 Rust tests pass; `cargo fmt`, `clippy -D
warnings` and `tsc` are clean.
