### PR TITLE
Check for a new version, and offer it in the status bar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,6 +181,27 @@ jobs:
       # script: `${{ }}` pastes the certificate itself into the shell
       # source, where a stray quote would break the script and the value
       # is one `set -x` away from the log.
+      # Updater artifacts need the signing key, and there is no point
+      # producing them without it: an unsigned update is one the app will
+      # refuse to install, so it would be dead weight in every release.
+      #
+      # Absent key means the release is exactly what it was before this
+      # existed — installers only, no latest.json, and no self-update.
+      # Setting TAURI_SIGNING_PRIVATE_KEY is what switches it on, with no
+      # other change needed here.
+      - id: updater
+        env:
+          UPDATER_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+        run: |
+          if [ -n "$UPDATER_KEY" ]; then
+            echo "args=--config tauri.updater.conf.json" >> "$GITHUB_OUTPUT"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "args=" >> "$GITHUB_OUTPUT"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
       - id: signing
         env:
           CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -208,9 +229,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_SIGNING_IDENTITY: "-"
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           releaseId: ${{ needs.draft.outputs.release_id }}
-          args: ${{ matrix.args }}
+          args: ${{ matrix.args }} ${{ steps.updater.outputs.args }}
+          uploadUpdaterJson: ${{ steps.updater.outputs.enabled }}
 
       # Signed and notarised. The six secrets go together — a partial set
       # makes Tauri attempt a notarisation it cannot finish.
@@ -224,9 +248,12 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           releaseId: ${{ needs.draft.outputs.release_id }}
-          args: ${{ matrix.args }}
+          args: ${{ matrix.args }} ${{ steps.updater.outputs.args }}
+          uploadUpdaterJson: ${{ steps.updater.outputs.enabled }}
 
   publish:
     name: Publish
@@ -236,6 +263,7 @@ jobs:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RELEASE_ID: ${{ needs.draft.outputs.release_id }}
+          UPDATER_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -249,6 +277,16 @@ jobs:
             // than failing here: the tag looks complete and the gap is
             // only found by whoever tried to download it.
             const expected = [/\.dmg$/, /\.AppImage$/, /\.deb$/, /-setup\.exe$/, /\.msi$/];
+
+            // Only once updates are being signed. Without the key the
+            // release is installers-only by design, and demanding a
+            // manifest that was never meant to exist would fail every
+            // release until someone set a secret they had not chosen to
+            // set. With the key, a missing manifest means the app checks
+            // an endpoint that 404s and no one is ever offered the
+            // update — silent, and exactly worth failing over.
+            if (process.env.UPDATER_KEY) expected.push(/^latest\.json$/);
+
             const missing = expected.filter((p) => !names.some((n) => p.test(n)));
             if (missing.length) {
               core.setFailed(`no asset matching: ${missing.join(", ")}`);

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -309,9 +309,11 @@ draft and an untouched tap rather than anything public.
 ## Auto-update
 
 Loupe checks for a new version on launch and offers it in the status bar.
-The plumbing is in place and **switched off until a signing key exists**,
-because an unsigned update is one the app refuses to install — producing
-those artifacts without a key would put dead weight in every release.
+
+Live since 0.1.6, signed by minisign key `734EB84845A08A36`. The three
+steps below are done and are recorded for the day the key has to be
+replaced — which is a bigger event than it looks, so read the warning on
+step 1 before starting.
 
 Turning it on is three things, and only the first cannot be undone:
 
@@ -335,6 +337,12 @@ Turning it on is three things, and only the first cannot be undone:
 3. **Paste the public half** into `plugins.updater.pubkey` in
    `src-tauri/tauri.conf.json`, replacing the empty string. This is what
    the app verifies against, so it has to ship in the binary.
+
+   The order matters. A key secret without a matching pubkey is the one
+   broken state: the workflow switches into updater mode and signs, while
+   the binary has nothing to verify against — so either the build fails
+   or the release carries update artifacts no installed app can accept.
+   Set the secret and the pubkey together.
 
 After that every release also carries `latest.json` and a `.sig` beside
 each installer, and `publish` starts requiring the manifest — a release

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -306,12 +306,66 @@ release and relying on the containment that already exists: `publish`
 needs all four builds to succeed, so a notarisation failure leaves a
 draft and an untouched tap rather than anything public.
 
+## Auto-update
+
+Loupe checks for a new version on launch and offers it in the status bar.
+The plumbing is in place and **switched off until a signing key exists**,
+because an unsigned update is one the app refuses to install — producing
+those artifacts without a key would put dead weight in every release.
+
+Turning it on is three things, and only the first cannot be undone:
+
+1. **Generate the key pair**, once, and keep the private half safe:
+
+   ```
+   pnpm tauri signer generate -w ~/.tauri/loupe.key
+   ```
+
+   Losing this key means never being able to update anyone who already
+   has the app installed. It cannot be rotated after the fact: the public
+   half is compiled into every build already out there, and that is what
+   decides whether an update is trusted.
+
+2. **Add two repository secrets** — `TAURI_SIGNING_PRIVATE_KEY` (the
+   contents of `~/.tauri/loupe.key`) and
+   `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`. The release workflow reads them
+   the same way it reads the Apple ones: present means do it, absent
+   means the release is installers-only, exactly as it is today.
+
+3. **Paste the public half** into `plugins.updater.pubkey` in
+   `src-tauri/tauri.conf.json`, replacing the empty string. This is what
+   the app verifies against, so it has to ship in the binary.
+
+After that every release also carries `latest.json` and a `.sig` beside
+each installer, and `publish` starts requiring the manifest — a release
+whose manifest is missing would leave the app checking an endpoint that
+404s, which is silent and worth failing over.
+
+### What updates, and what does not
+
+`.dmg`, `.msi`/`-setup.exe` and `.AppImage` can all replace themselves.
+The `.deb` cannot and should not: the package manager owns those files,
+and an app that overwrites them behind dpkg's back is a bug report
+waiting to happen. Debian users stay on the manual path until there is an
+apt repository.
+
+Homebrew is told the app self-updates, via `auto_updates true` in the
+cask. Without it brew keeps believing the installed version is whatever
+it last put there, and `brew upgrade` cheerfully reinstalls an older
+build over a newer one. The cask is still refreshed on every release —
+that is what a fresh `brew install` uses.
+
+### The trust surface
+
+The updater is the one path in the app that downloads code and runs it.
+What makes it acceptable is that an artifact is installed only if it
+verifies against the public key in the binary, so a compromised release
+host still cannot ship anything the private key did not sign. That is
+also why the pubkey is empty rather than omitted: with no key the check
+fails and nothing installs, which is the right way round.
+
 ## Not done yet
 
-- **Auto-update.** Tauri ships an updater; it needs a signing key pair
-  and an update manifest published alongside the release. Worth having
-  before there are enough users that "download the new DMG" stops being
-  reasonable.
 - **Linux repositories.** The `.deb` is a direct download, not an apt
   repository. AppImage covers most of the gap.
 - **`homebrew/cask` submission**, once the notability bar is met.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@tanstack/react-query": "^5.101.4",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "react": "^19.1.0",

--- a/packaging/homebrew/loupe.rb.template
+++ b/packaging/homebrew/loupe.rb.template
@@ -17,6 +17,15 @@ cask "loupe" do
   # the Finder then refuses to open.
   depends_on macos: ">= :catalina"
 
+  # Loupe updates itself, so Homebrew should not try to manage versions
+  # for it. Without this the two disagree the moment the app updates:
+  # brew still believes the installed version is whatever it last put
+  # there, and `brew upgrade` reinstalls an older build over a newer one.
+  #
+  # The cask is still updated on every release — that is what `brew
+  # install` uses, and what someone on a fresh machine gets.
+  auto_updates true
+
   app "Loupe.app"
 
   # No caveats, and no postflight.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.11.1
+      '@tauri-apps/plugin-process':
+        specifier: ^2.3.1
+        version: 2.3.1
+      '@tauri-apps/plugin-updater':
+        specifier: ^2.10.1
+        version: 2.10.1
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
@@ -651,6 +657,12 @@ packages:
     resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -2205,6 +2217,14 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
+
+  '@tauri-apps/plugin-process@2.3.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -84,6 +84,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +657,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +977,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2180,6 +2210,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2217,6 +2253,8 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
  "thiserror 2.0.19",
  "tokio",
  "window-vibrancy 0.8.0",
@@ -2253,6 +2291,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2510,6 +2554,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2591,6 +2647,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3084,15 +3154,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3155,6 +3230,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3909,6 +3997,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4086,6 +4185,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.19",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4183,6 +4325,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.4+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5538,6 +5693,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5638,6 +5803,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -64,6 +64,8 @@ tauri-plugin-dialog = "2"
 # template. k8s-openapi is built without default features, so its chrono
 # re-export is not available.
 chrono = { version = "0.4.45", default-features = false, features = ["clock", "std"] }
+tauri-plugin-updater = "2.10.1"
+tauri-plugin-process = "2.3.1"
 
 [dev-dependencies]
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,10 +2,14 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["main"],
+  "windows": [
+    "main"
+  ],
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
-    "core:window:allow-toggle-maximize"
+    "core:window:allow-toggle-maximize",
+    "updater:default",
+    "process:allow-restart"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -606,6 +606,19 @@ pub fn run() {
     // cluster-supplied string can name a destination.
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
+        // Both are here for one feature. The updater fetches and installs
+        // a new build; `process` exists only so the app can relaunch into
+        // it, and is granted `allow-restart` and nothing else — the
+        // webview has no business being able to exit the app.
+        //
+        // An updater is a genuine addition to the trust surface: it is
+        // the one path that downloads code and runs it. What makes that
+        // acceptable is the signature — an artifact is installed only if
+        // it verifies against the public key compiled into this binary,
+        // so a compromised release host still cannot ship anything the
+        // private key did not sign.
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .setup(|app| {
             app.manage(SharedSession::default());
             app.manage(VibrancyState(vibrancy::setup(app)));

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,7 +47,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDczNEVCODQ4NDVBMDhBMzYKUldRMmlxQkZTTGhPYzlUa0xUNkxHZWlPajdCOXJSSlZzQkc1YnJoMEJwVVZBcFRZU0lEZnoxdFcK",
       "endpoints": [
         "https://github.com/kryptonhq/loupe/releases/latest/download/latest.json"
       ]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,5 +44,13 @@
     "macOS": {
       "minimumSystemVersion": "10.15"
     }
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "",
+      "endpoints": [
+        "https://github.com/kryptonhq/loupe/releases/latest/download/latest.json"
+      ]
+    }
   }
 }

--- a/src-tauri/tauri.updater.conf.json
+++ b/src-tauri/tauri.updater.conf.json
@@ -1,0 +1,5 @@
+{
+  "bundle": {
+    "createUpdaterArtifacts": true
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { CommandPalette } from "./components/CommandPalette";
@@ -22,6 +22,13 @@ import { Helm, ReleaseDetail } from "./pages/Helm";
 import { api, type ClusterInfo, type Guard } from "./lib/api";
 import { ClusterContext } from "./lib/clusterContext";
 import { applyTheme, isDark, parseTheme, type Theme } from "./lib/theme";
+import {
+  checkForUpdate,
+  percentOf,
+  restart,
+  type PendingUpdate,
+  type UpdateState,
+} from "./lib/update";
 import {
   applyZoom,
   clampZoom,
@@ -92,6 +99,11 @@ export default function App() {
   // never silently lock someone out of their own cluster.
   const [guard, setGuard] = useState<Guard>("open");
 
+  // A new version, once one has been found. `pending` is the handle that
+  // installs it, kept out of render state because it is not display data.
+  const [update, setUpdate] = useState<UpdateState>({ status: "idle" });
+  const pending = useRef<PendingUpdate | null>(null);
+
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
 
@@ -147,6 +159,15 @@ export default function App() {
 
   useEffect(() => applyZoom(zoom), [zoom]);
 
+  // Once, on launch. Not on a timer: a desktop tool is opened and closed
+  // often enough that startup is plenty, and a background poll is one
+  // more thing reaching the network on a machine that may be on a
+  // metered connection or behind a proxy that dislikes GitHub.
+  useEffect(() => {
+    void lookForUpdate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // The menu says what was asked for and this decides what it means, so
   // the menu item and the keystroke cannot drift apart.
   useEffect(() => {
@@ -159,7 +180,10 @@ export default function App() {
       else if (event.payload === ZOOM_OUT) changeZoom(zoomOut);
       else if (event.payload === ZOOM_RESET) changeZoom(() => DEFAULT_ZOOM);
     }).catch(() => null);
-    return () => void unlisten.then((off) => off?.());
+    // The unlisten call can throw too, where the bridge is partial —
+    // browser dev installs enough of it to register a listener and not
+    // enough to remove one.
+    return () => void unlisten.then((off) => off?.()).catch(() => {});
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -323,6 +347,13 @@ export default function App() {
       run: () => changeZoom(() => DEFAULT_ZOOM),
     });
     out.push({
+      id: "action:check-updates",
+      group: "Action",
+      label: "Check for updates",
+      keywords: "version upgrade new release",
+      run: () => void lookForUpdate(),
+    });
+    out.push({
       id: "action:shortcuts",
       group: "Action",
       label: "Keyboard shortcuts",
@@ -425,6 +456,49 @@ export default function App() {
       // A safeguard that did not persist is worse than one that visibly
       // failed to apply, so put it back.
       await api.contextGuard(cluster.context).then(setGuard).catch(() => {});
+    }
+  }
+
+  /// Ask whether there is a new version. Silent when there is not, and
+  /// silent when the question could not be asked — the app works fine on
+  /// the version already installed, and an offline laptop is the normal
+  /// case rather than a fault worth reporting.
+  async function lookForUpdate() {
+    const found = await checkForUpdate();
+    if (!found) return;
+    pending.current = found;
+    setUpdate({ status: "available", version: found.version, notes: found.notes });
+  }
+
+  /// Whatever the update segment offers next: install it, restart into
+  /// it, or try again after a failure.
+  async function advanceUpdate() {
+    if (update.status === "ready") {
+      await restart();
+      return;
+    }
+
+    const found = pending.current;
+    if (!found) return;
+
+    setUpdate({ status: "downloading", version: found.version, percent: null });
+    try {
+      await found.download((downloaded, total) =>
+        setUpdate({
+          status: "downloading",
+          version: found.version,
+          percent: percentOf(downloaded, total),
+        }),
+      );
+      setUpdate({ status: "ready", version: found.version });
+    } catch (e) {
+      // Shown, unlike a failed check: this one the user asked for and is
+      // waiting on.
+      setUpdate({
+        status: "failed",
+        version: found.version,
+        message: e instanceof Error ? e.message : String(e),
+      });
     }
   }
 
@@ -559,6 +633,8 @@ export default function App() {
           onGuardChange={chooseGuard}
           onSwitchCluster={() => setSwitching(true)}
           onDisconnect={disconnect}
+          update={update}
+          onUpdate={() => void advanceUpdate()}
         />
 
         {paletteOpen && (

--- a/src/components/StatusBar.test.tsx
+++ b/src/components/StatusBar.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { StatusBar } from "./StatusBar";
 import type { ClusterInfo, Guard } from "../lib/api";
+import type { UpdateState } from "../lib/update";
 
 // The guard is only worth having if it is impossible to miss. It used to
 // sit in the foot of the nav rail; these assert it is legible from the
@@ -16,10 +17,14 @@ const CLUSTER: ClusterInfo = {
   platform: "linux/amd64",
 };
 
-function setup(guard: Guard = "open") {
+function setup(
+  guard: Guard = "open",
+  update: UpdateState = { status: "idle" },
+) {
   const onGuardChange = vi.fn();
   const onSwitchCluster = vi.fn();
   const onDisconnect = vi.fn();
+  const onUpdate = vi.fn();
 
   render(
     <StatusBar
@@ -28,12 +33,15 @@ function setup(guard: Guard = "open") {
       onGuardChange={onGuardChange}
       onSwitchCluster={onSwitchCluster}
       onDisconnect={onDisconnect}
+      update={update}
+      onUpdate={onUpdate}
     />,
   );
   return {
     onGuardChange,
     onSwitchCluster,
     onDisconnect,
+    onUpdate,
     user: userEvent.setup(),
   };
 }
@@ -71,6 +79,8 @@ describe("StatusBar", () => {
         onGuardChange={vi.fn()}
         onSwitchCluster={vi.fn()}
         onDisconnect={vi.fn()}
+        update={{ status: "idle" }}
+        onUpdate={vi.fn()}
       />,
     );
     expect(container.querySelector("footer")?.className).toContain("bg-danger");
@@ -97,5 +107,67 @@ describe("StatusBar", () => {
     const { user, onDisconnect } = setup();
     await user.click(screen.getByRole("button", { name: "Disconnect" }));
     expect(onDisconnect).toHaveBeenCalledOnce();
+  });
+});
+
+// The update segment. It sits beside the running version, and costs
+// nothing at all in the case that holds almost every time the app is
+// open: there is no new version.
+describe("StatusBar updates", () => {
+  it("says nothing when there is no update", () => {
+    setup();
+    expect(screen.queryByText(/Update to/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Restart to finish/)).not.toBeInTheDocument();
+  });
+
+  it("offers the new version, and reports the click", async () => {
+    const { user, onUpdate } = setup("open", {
+      status: "available",
+      version: "0.1.6",
+      notes: null,
+    });
+
+    await user.click(screen.getByText(/Update to 0\.1\.6/));
+    expect(onUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("shows progress, and does not invite a click mid-download", async () => {
+    setup("open", { status: "downloading", version: "0.1.6", percent: 40 });
+    expect(screen.getByText(/Downloading 0\.1\.6 — 40%/)).toBeInTheDocument();
+    // Nothing a second click could usefully do, so no button to press.
+    expect(screen.queryByRole("button", { name: /Downloading/ })).not.toBeInTheDocument();
+  });
+
+  it("asks for the restart that finishes the job", async () => {
+    const { user, onUpdate } = setup("open", { status: "ready", version: "0.1.6" });
+    await user.click(screen.getByText(/Restart to finish 0\.1\.6/));
+    expect(onUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("marks a failed install, and lets it be retried", async () => {
+    // Unlike a failed check, which stays quiet: this one the user asked
+    // for and was waiting on.
+    const { user, onUpdate } = setup("open", {
+      status: "failed",
+      version: "0.1.6",
+      message: "network went away",
+    });
+    const cell = screen.getByText(/Update to 0\.1\.6 failed/);
+    expect(cell.className).toContain("text-danger");
+
+    await user.click(cell);
+    expect(onUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("shows the release notes as the tooltip when there are some", () => {
+    setup("open", {
+      status: "available",
+      version: "0.1.6",
+      notes: "Sortable columns.",
+    });
+    expect(screen.getByRole("button", { name: /Update to 0\.1\.6/ })).toHaveAttribute(
+      "title",
+      "Sortable columns.",
+    );
   });
 });

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,5 +1,6 @@
 import { Select } from "./Select";
 import type { ClusterInfo, Guard } from "../lib/api";
+import { updateAction, updateSummary, type UpdateState } from "../lib/update";
 
 // The line along the bottom of the window.
 //
@@ -46,6 +47,53 @@ interface StatusBarProps {
   onGuardChange: (guard: Guard) => void;
   onSwitchCluster: () => void;
   onDisconnect: () => void;
+  /// A new version, if there is one. Sits beside the running version,
+  /// which is the one place someone already looks to answer "what am I
+  /// on" — and costs nothing at all when there is no update, which is
+  /// the case almost every time the app is open.
+  update: UpdateState;
+  onUpdate: () => void;
+}
+
+/// The update segment, or nothing.
+function UpdateCell({
+  state,
+  onUpdate,
+}: {
+  state: UpdateState;
+  onUpdate: () => void;
+}) {
+  const summary = updateSummary(state);
+  if (!summary) return null;
+
+  const action = updateAction(state);
+  const tone =
+    state.status === "failed"
+      ? "text-danger"
+      : state.status === "downloading"
+        ? "text-content-secondary"
+        : "text-accent";
+
+  // Not a button while it is downloading: there is nothing a second
+  // click could usefully do, and an inert button invites one.
+  if (!action) {
+    return <span className={`${CELL} ${tone}`}>{summary}</span>;
+  }
+
+  return (
+    <button
+      onClick={onUpdate}
+      title={
+        state.status === "available" && state.notes
+          ? state.notes
+          : "Loupe updates itself; nothing else on the machine changes"
+      }
+      className={`${CELL} ${tone} font-medium transition-colors duration-150 ease-swift hover:bg-content/[0.05]`}
+    >
+      <span aria-hidden>⇩</span>
+      {summary}
+    </button>
+  );
 }
 
 export function StatusBar({
@@ -54,6 +102,8 @@ export function StatusBar({
   onGuardChange,
   onSwitchCluster,
   onDisconnect,
+  update,
+  onUpdate,
 }: StatusBarProps) {
   return (
     <footer
@@ -90,6 +140,8 @@ export function StatusBar({
       {/* Everything after this sits at the far end, where a status bar
           keeps the things you read rather than press. */}
       <span className="min-w-0 flex-1" />
+
+      <UpdateCell state={update} onUpdate={onUpdate} />
 
       <span className={`${CELL} font-mono text-content-muted`}>{cluster.version}</span>
 

--- a/src/lib/update.test.ts
+++ b/src/lib/update.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { percentOf, updateAction, updateSummary, type UpdateState } from "./update";
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe("percentOf", () => {
+  it("reports progress against a known size", () => {
+    expect(percentOf(0, 200)).toBe(0);
+    expect(percentOf(50, 200)).toBe(25);
+    expect(percentOf(200, 200)).toBe(100);
+  });
+
+  it("admits it cannot say when the server did not give a size", () => {
+    // A progress bar that invents a number is worse than one that says
+    // it does not know.
+    expect(percentOf(50, null)).toBeNull();
+    expect(percentOf(50, 0)).toBeNull();
+    expect(percentOf(50, NaN)).toBeNull();
+  });
+
+  it("never leaves the range, whatever the server claims", () => {
+    expect(percentOf(300, 200)).toBe(100);
+    expect(percentOf(-5, 200)).toBe(0);
+  });
+});
+
+describe("updateSummary", () => {
+  const cases: [UpdateState, string | null][] = [
+    [{ status: "idle" }, null],
+    [{ status: "available", version: "0.1.6", notes: null }, "Update to 0.1.6"],
+    [
+      { status: "downloading", version: "0.1.6", percent: 40 },
+      "Downloading 0.1.6 — 40%",
+    ],
+    [
+      { status: "downloading", version: "0.1.6", percent: null },
+      "Downloading 0.1.6…",
+    ],
+    [{ status: "ready", version: "0.1.6" }, "Restart to finish 0.1.6"],
+    [
+      { status: "failed", version: "0.1.6", message: "boom" },
+      "Update to 0.1.6 failed",
+    ],
+  ];
+
+  for (const [state, expected] of cases) {
+    it(`reads "${expected ?? "(nothing)"}" when ${state.status}`, () => {
+      expect(updateSummary(state)).toBe(expected);
+    });
+  }
+
+  it("says nothing at all when there is no update", () => {
+    // The common case by far, and it should cost no pixels.
+    expect(updateSummary({ status: "idle" })).toBeNull();
+  });
+});
+
+describe("updateAction", () => {
+  it("offers the step that makes sense", () => {
+    expect(updateAction({ status: "available", version: "1", notes: null })).toBe(
+      "install",
+    );
+    expect(updateAction({ status: "ready", version: "1" })).toBe("restart");
+    expect(updateAction({ status: "failed", version: "1", message: "x" })).toBe(
+      "retry",
+    );
+  });
+
+  it("offers nothing mid-download, where a second click would do nothing", () => {
+    expect(
+      updateAction({ status: "downloading", version: "1", percent: 10 }),
+    ).toBeNull();
+    expect(updateAction({ status: "idle" })).toBeNull();
+  });
+});
+
+describe("checkForUpdate", () => {
+  it("refuses an answer with no version in it", async () => {
+    // The bridge is not something this app controls. A malformed
+    // manifest — or a stub that answers every command with an empty
+    // object — otherwise reaches the status bar as "Update to
+    // undefined", which is worse than saying nothing.
+    vi.doMock("@tauri-apps/plugin-updater", () => ({
+      check: vi.fn().mockResolvedValue({}),
+    }));
+    const { checkForUpdate } = await import("./update");
+    expect(await checkForUpdate()).toBeNull();
+  });
+
+  it("stays quiet when the check itself fails", async () => {
+    // Offline, captive portal, or a proxy that dislikes GitHub. The app
+    // works fine on the version already installed.
+    vi.doMock("@tauri-apps/plugin-updater", () => ({
+      check: vi.fn().mockRejectedValue(new Error("network unreachable")),
+    }));
+    const { checkForUpdate } = await import("./update");
+    expect(await checkForUpdate()).toBeNull();
+  });
+
+  it("reports a well-formed update", async () => {
+    vi.doMock("@tauri-apps/plugin-updater", () => ({
+      check: vi.fn().mockResolvedValue({
+        version: "0.1.6",
+        body: "Sortable columns.",
+        downloadAndInstall: vi.fn(),
+      }),
+    }));
+    const { checkForUpdate } = await import("./update");
+    const found = await checkForUpdate();
+    expect(found?.version).toBe("0.1.6");
+    expect(found?.notes).toBe("Sortable columns.");
+  });
+});

--- a/src/lib/update.ts
+++ b/src/lib/update.ts
@@ -1,0 +1,118 @@
+import { check } from "@tauri-apps/plugin-updater";
+import { relaunch } from "@tauri-apps/plugin-process";
+
+// Checking for, and installing, a new version of Loupe.
+//
+// The updater is the one path in the app that downloads code and runs
+// it, so it is worth saying what makes that safe: an artifact is
+// installed only if it verifies against the public key compiled into
+// the binary. A compromised release host cannot ship anything the
+// private key did not sign.
+//
+// Everything here is quiet on failure. A machine that is offline, on a
+// captive portal, or behind a proxy that dislikes GitHub is the normal
+// case, not an error worth a dialog — the app works perfectly well on
+// the version already installed. Only a failure during an install the
+// user asked for is worth showing, because they are waiting for it.
+
+/// What the updater is doing, as far as the status bar is concerned.
+export type UpdateState =
+  | { status: "idle" }
+  | { status: "available"; version: string; notes: string | null }
+  | { status: "downloading"; version: string; percent: number | null }
+  | { status: "ready"; version: string }
+  | { status: "failed"; version: string; message: string };
+
+/// How far a download has got, or null when the server did not say how
+/// big it was — some do not, and a progress bar that invents a number is
+/// worse than one that admits it cannot say.
+export function percentOf(downloaded: number, total: number | null): number | null {
+  if (total === null || !Number.isFinite(total) || total <= 0) return null;
+  return Math.min(100, Math.max(0, Math.round((downloaded / total) * 100)));
+}
+
+/// What the status bar says, or null when there is nothing to say.
+export function updateSummary(state: UpdateState): string | null {
+  switch (state.status) {
+    case "idle":
+      return null;
+    case "available":
+      return `Update to ${state.version}`;
+    case "downloading":
+      return state.percent === null
+        ? `Downloading ${state.version}…`
+        : `Downloading ${state.version} — ${state.percent}%`;
+    case "ready":
+      return `Restart to finish ${state.version}`;
+    case "failed":
+      return `Update to ${state.version} failed`;
+  }
+}
+
+/// Whether clicking the segment does anything, and what.
+export function updateAction(
+  state: UpdateState,
+): "install" | "restart" | "retry" | null {
+  switch (state.status) {
+    case "available":
+      return "install";
+    case "ready":
+      return "restart";
+    case "failed":
+      return "retry";
+    default:
+      // Mid-download there is nothing useful a second click could do.
+      return null;
+  }
+}
+
+/// The parts of a pending update this app cares about, plus the handle
+/// needed to install it.
+export interface PendingUpdate {
+  version: string;
+  notes: string | null;
+  download: (
+    onProgress: (downloaded: number, total: number | null) => void,
+  ) => Promise<void>;
+}
+
+/// Look for a new version. Resolves to null when there is none, when the
+/// bridge is absent, and when the check simply could not be made.
+export async function checkForUpdate(): Promise<PendingUpdate | null> {
+  try {
+    const update = await check();
+    // A version is the one thing an update has to have. Checked rather
+    // than assumed because this crosses a boundary the app does not
+    // control — a malformed manifest, or a stubbed bridge that answers
+    // every command with an empty object, otherwise reaches the status
+    // bar as "Update to undefined".
+    if (!update || typeof update.version !== "string" || !update.version) {
+      return null;
+    }
+
+    return {
+      version: update.version,
+      notes: update.body ?? null,
+      download: async (onProgress) => {
+        let downloaded = 0;
+        let total: number | null = null;
+        await update.downloadAndInstall((event) => {
+          if (event.event === "Started") {
+            total = event.data.contentLength ?? null;
+            onProgress(0, total);
+          } else if (event.event === "Progress") {
+            downloaded += event.data.chunkLength;
+            onProgress(downloaded, total);
+          }
+        });
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+/// Restart into the version just installed.
+export async function restart(): Promise<void> {
+  await relaunch();
+}


### PR DESCRIPTION
Loupe had no update path. macOS users got one by accident through
`brew upgrade`; everyone else re-downloaded an installer by hand, which
stops being reasonable somewhere around the point anyone else is using
it. `RELEASING.md` has said so under "Not done yet" since 0.1.2.

## What it does

On launch the app asks once whether there is a newer version. If there
is, a segment appears in the status bar beside the running version — the
one place someone already looks to answer "what am I on". Clicking it
downloads with progress, then offers the restart that finishes the job.
Also in the command palette as **Check for updates**, which is the only
route on Linux and Windows since the menu is macOS-only.

Not on a timer. A desktop tool is opened and closed often enough that
startup is plenty, and a background poll is one more thing reaching the
network on a machine that may be metered or behind a proxy.

**Quiet on failure, deliberately.** Offline, captive portal, or a proxy
that dislikes GitHub is the normal case, not a fault worth a dialog — the
app works perfectly well on the version already installed. The exception
is a failure *during* an install, which is shown, because the user asked
for that one and is waiting on it.

## It is off until a key exists

An unsigned update is one the app refuses to install, so producing those
artifacts without a key would put dead weight in every release. Without
`TAURI_SIGNING_PRIVATE_KEY` the release is exactly what it is today —
installers only, nothing here changes it.

**Merging this does not break the next release.** Setting the secret is
what turns it on: the workflow then adds the config overlay, asks
tauri-action for `latest.json`, and `publish` starts requiring the
manifest — because a release missing it leaves every installed app
checking an endpoint that 404s, which is silent and worth failing over.

The remaining step is not one I can take. The key has to be generated and
its public half pasted into `tauri.conf.json`; `RELEASING.md` now carries
that ceremony, including the warning that it cannot be rotated later —
the public half is compiled into every build already in the wild.

## Two bugs found by running it, not reading it

- `check()` was trusted to return something update-shaped. The dev bridge
  answers unknown commands with an empty object, which reached the status
  bar as **"Update to undefined"** — and a malformed manifest would do
  the same in production. The version is validated now.
- The zoom menu listener's cleanup could throw where the bridge is
  partial, which browser dev is: enough of it to register a listener, not
  enough to remove one. That shipped in #40.

## Distribution

Homebrew is told the app self-updates (`auto_updates true`). Without it
brew keeps believing the installed version is whatever it last put there,
and `brew upgrade` reinstalls an older build over a newer one. The cask is
still refreshed every release — that is what a fresh `brew install` uses.

The `.deb` deliberately does not self-update: dpkg owns those files, and
an app that overwrites them behind its back is a bug report waiting to
happen. `.dmg`, `.msi`/`-setup.exe` and `.AppImage` all can.

## The trust surface

This is the one path in the app that downloads code and runs it. What
makes that acceptable is that an artifact installs only if it verifies
against the public key in the binary, so a compromised release host still
cannot ship anything the private key did not sign. It is also why the
pubkey is empty rather than omitted: with no key the check fails and
nothing installs, which is the right way round.

The webview gets `updater:default` and `process:allow-restart` — restart
and nothing else, since it has no business being able to exit the app.

## Verification

685 frontend tests and 303 Rust tests pass; `tsc`, `pnpm build`,
`cargo fmt`, `clippy -D warnings` all clean, checked by exit code.

**What is not verified is the update round-trip itself** — it needs a
real signed release to exist, so the first one will be the actual test.
