### PR TITLE
A changelog, and release notes worth reading

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,27 @@ jobs:
         with:
           ref: ${{ needs.version.outputs.tag }}
 
+      # The release body, from CHANGELOG.md. Without it the body is
+      # whatever `generate_release_notes` produces, which is a list of
+      # merged pull request titles — accurate, and not something anyone
+      # reads to decide whether to update.
+      #
+      # Missing section is not fatal: the script exits non-zero, no file
+      # is written, and the step below falls back to the generated notes
+      # rather than publishing an empty body.
+      - id: notes
+        env:
+          TAG: ${{ needs.version.outputs.tag }}
+        run: |
+          if python3 scripts/release-notes.py "$TAG" > "$RUNNER_TEMP/notes.md"; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            rm -f "$RUNNER_TEMP/notes.md"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::no CHANGELOG.md section for $TAG; falling back to generated notes"
+          fi
+        shell: bash
+
       - id: create
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -79,10 +100,21 @@ jobs:
           # `inputs.tag`, and interpolating it into the script body would
           # let it close the string and run as JavaScript.
           TAG: ${{ needs.version.outputs.tag }}
+          NOTES: ${{ runner.temp }}/notes.md
+          HAVE_NOTES: ${{ steps.notes.outputs.found }}
         with:
           script: |
+            const fs = require("fs");
             const tag = process.env.TAG;
             const { owner, repo } = context.repo;
+
+            // Read through the environment rather than interpolated, so
+            // a changelog entry containing a backtick or a quote cannot
+            // close the script and run as JavaScript.
+            const body =
+              process.env.HAVE_NOTES === "true"
+                ? fs.readFileSync(process.env.NOTES, "utf8").trim()
+                : "";
 
             // Reuse the draft if this is a retry, rather than stacking
             // up a second release for the same tag.
@@ -98,7 +130,8 @@ jobs:
               tag_name: tag,
               name: `Loupe ${tag}`,
               draft: true,
-              generate_release_notes: true,
+              body: body || undefined,
+              generate_release_notes: body === "",
             });
             return created.data.id;
           result-encoding: string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,94 @@
+# Changelog
+
+Notable changes, newest first. Versions follow
+[semantic versioning](https://semver.org), with the caveat that on 0.x
+the middle number carries the weight a major would.
+
+This file starts at 0.1.5. Earlier releases are on the
+[releases page](https://github.com/kryptonhq/loupe/releases); 0.1.3 and
+0.1.4 exist only as version bumps and were never published.
+
+## [0.1.5] — 2026-08-20
+
+The first release since 0.1.2, and a large one: everything below either
+had no public build at all or is new since.
+
+### Added
+
+- **Tabs, and a history behind each one.** The main area used to render
+  exactly one view, so opening a pod lost the list it came from and
+  following a related object was a one-way trip. Tabs open with ⌘T,
+  close with ⌘W, and ⌘-clicking a row opens it in one of its own; ⌘[ and
+  ⌘] walk a real back/forward history per tab.
+- **A status bar.** Cluster, guard, server version and any pending
+  update, on one line that does not move. The cluster and its write
+  guard used to live in the foot of the nav rail, which is no help once
+  you are three panes deep in a manifest.
+- **Sortable columns**, in the units the columns are actually in. Ages
+  sort as durations, ready counts as fractions, restarts as numbers —
+  so `10m` no longer sorts before `2d`, and `pod-2` comes before
+  `pod-10`. Sorting a partly loaded listing says so.
+- **Auto-update.** Loupe checks once on launch and offers a new version
+  in the status bar, verified against a signing key compiled into the
+  binary. Also in the command palette as *Check for updates*.
+- **Interface zoom** — ⌘+, ⌘− and ⌘0, from the View menu, the keyboard
+  or the palette, remembered across launches.
+- **Several clusters stay connected.** Switching back to one
+  re-authenticates nothing and re-walks no API discovery.
+- **Exec into a container**, through a real terminal emulator rather
+  than a text box that sends lines.
+- **Port-forward manager**, with forwards visible while they run instead
+  of a terminal you have to leave open.
+- **Operator actions** — scale, rollout restart, delete, cordon and
+  drain — behind confirmations, and hidden entirely where RBAC says no.
+- **Merged log view.** Tail every pod of a workload in one stream,
+  colour-coded per pod, instead of opening them one at a time.
+- **Log filtering, highlighting, and copy or save** of what is on
+  screen.
+- **Related-object navigation** — owners, selectors and references, so
+  a pod is no longer an island.
+- **Protected and read-only contexts**, marked per context, with a diff
+  shown before every apply.
+- **Command palette** (⌘K) and keyboard-first navigation.
+
+### Changed
+
+- **A mark of Loupe's own.** The app wore the Krypton mark, byte for
+  byte the same file as the runtime's operator UI. The new one is a lens
+  iris whose opening keeps the family's hexagon — and, unlike its
+  predecessor's 1px lattice, survives being 16 pixels wide.
+- **Breadcrumbs describe where an object sits**, not how you got there.
+  They used to be the tab's visited history, which produced trails like
+  `Nodes › Pods › some-pod › Jobs › DaemonSets` — six steps, none
+  containing the next, in the one element whose meaning is containment.
+- **Content sits in front of the chrome.** The surface ramp was defined
+  and never painted, so a table fell through to the window background
+  while every bar of chrome around it was brighter. Light and dark now
+  both run base → glass → content.
+- **Listings are paged and watched.** A page is fetched at a time, so
+  time to first row follows the page size rather than the size of the
+  cluster, and freshness comes from a watch rather than a ten-second
+  timer.
+- **The context picker stays instant** on a kubeconfig with thousands of
+  contexts: search text is built once rather than per keystroke, only
+  visible rows are in the DOM, and recents and pins sit above everything.
+- **The log viewer keeps up with chatty pods** — lines batched on the
+  Rust side, coalesced onto animation frames, and only the visible ones
+  in the DOM.
+
+### Fixed
+
+- A listing's namespace filter, search and sort survive opening a row
+  and coming back. They used to live in the page, which unmounts.
+- The terminal no longer rebuilds itself on every render, mangles its
+  own output, or ships without the stylesheet that makes it a terminal.
+- Switching cluster no longer leaves tabs pointing at objects that do
+  not exist in the new one.
+
+### Notes
+
+- Anyone on 0.1.2 must update by `brew upgrade` or a fresh download —
+  there was no updater to offer them this one. From 0.1.5 onward Loupe
+  can update itself.
+- Homebrew is told the app self-updates, so `brew upgrade` no longer
+  reinstalls an older build over a newer one.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -310,7 +310,7 @@ draft and an untouched tap rather than anything public.
 
 Loupe checks for a new version on launch and offers it in the status bar.
 
-Live since 0.1.6, signed by minisign key `734EB84845A08A36`. The three
+Live since 0.1.5, signed by minisign key `734EB84845A08A36`. The three
 steps below are done and are recorded for the day the key has to be
 replaced — which is a bigger event than it looks, so read the warning on
 step 1 before starting.

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Pull one version's section out of CHANGELOG.md.
+
+The release workflow seeds the GitHub release body with this. Without it
+the body is whatever `generate_release_notes` produces, which is a list
+of merged pull request titles — accurate, and not something anyone wants
+to read to find out whether it is worth updating.
+
+    scripts/release-notes.py v0.1.5    # print that section
+    scripts/release-notes.py v9.9.9    # exit 1, nothing printed
+
+Exits non-zero when there is no section, so the caller can fall back
+rather than publishing an empty body.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+CHANGELOG = pathlib.Path(__file__).resolve().parent.parent / "CHANGELOG.md"
+
+
+def section(text: str, version: str) -> str | None:
+    """The body under `## [version]`, up to the next `## ` heading."""
+    # Tolerates both `## [0.1.5] - date` and `## 0.1.5`, and a tag that
+    # arrives with or without its leading v.
+    wanted = version.lstrip("v")
+    pattern = re.compile(
+        r"^##\s+\[?" + re.escape(wanted) + r"\]?.*?$(.*?)(?=^##\s|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    found = pattern.search(text)
+    if not found:
+        return None
+    body = found.group(1).strip()
+    return body or None
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    if not CHANGELOG.exists():
+        print(f"no {CHANGELOG.name}", file=sys.stderr)
+        return 1
+
+    body = section(CHANGELOG.read_text(), sys.argv[1])
+    if body is None:
+        print(f"no section for {sys.argv[1]} in {CHANGELOG.name}", file=sys.stderr)
+        return 1
+
+    print(body)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Needed before cutting 0.1.5.

The release body was whatever `generate_release_notes` produced: a list
of merged pull request titles. Accurate, and not something anyone reads
to decide whether an update is worth taking — which matters more now
that the app offers updates itself rather than waiting to be fetched.

## What this adds

**`CHANGELOG.md`**, starting at 0.1.5. That is the first release since
0.1.2, and it carries everything from the three versions in between that
were bumped in the manifests but never published — exec, port-forward,
operator actions, guards and apply diffs, watch-driven listings,
server-side paging, merged logs, the command palette, the context picker
at scale — plus this month's workbench shell, auto-update and new mark.

**`scripts/release-notes.py`**, which pulls one version's section out of
it, and a `notes` step in the release workflow that seeds the draft's
body with the result.

A missing section is not fatal: the extractor exits non-zero, the step
emits a warning, and the body falls back to the generated notes rather
than publishing nothing.

The body is read through the environment rather than interpolated into
the script, for the same reason the tag already is — a changelog entry
containing a backtick should not be able to close the script and run as
JavaScript.

Also corrects `RELEASING.md`, which claimed the updater was live since
0.1.6. It ships in 0.1.5.

## Not changed

The version. The manifests already say 0.1.5 and `scripts/version.py
--check v0.1.5` passes, so the tag can be cut from this once merged.
