### PR TITLE
Resolve the updater overlay from the repository root

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,8 +226,22 @@ jobs:
         env:
           UPDATER_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
         run: |
+          # Path is relative to the repository root, not to src-tauri.
+          # Both tauri-action's own check and the CLI resolve it from the
+          # working directory, and v0.1.5's first run died on all four
+          # platforms because this said `tauri.updater.conf.json`.
+          OVERLAY=src-tauri/tauri.updater.conf.json
+
           if [ -n "$UPDATER_KEY" ]; then
-            echo "args=--config tauri.updater.conf.json" >> "$GITHUB_OUTPUT"
+            # Fail here rather than four platforms later. The overlay is
+            # what turns updater artifacts on; a release that quietly
+            # built without it would publish a manifest-less release to
+            # apps that are now checking for one.
+            if [ ! -f "$OVERLAY" ]; then
+              echo "::error::$OVERLAY is missing, but a signing key is set"
+              exit 1
+            fi
+            echo "args=--config $OVERLAY" >> "$GITHUB_OUTPUT"
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "args=" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
v0.1.5's first release run failed on all four platforms:

```
Provided config path .../loupe/tauri.updater.conf.json does not exist
```

The overlay lives in `src-tauri/`, but both tauri-action's own check and the Tauri CLI resolve `--config` from the working directory — the repository root. Verified rather than assumed: a bad path errors on the spot, and `src-tauri/tauri.updater.conf.json` gets through to the build.

**Nothing was published.** `publish` requires all four builds, so the run left a draft and an untouched Homebrew tap — which is what that gate is for. The tag does not need moving; once this merges the run can be retried from the Actions tab against `v0.1.5`.

Also makes the step fail outright if the overlay goes missing while a signing key is set, rather than building four platforms and finding out at the end. The overlay is what turns updater artifacts on, and a release that quietly built without it would publish no manifest to apps that are now checking for one — silent, and the exact failure mode this release is meant to start testing.